### PR TITLE
REPL + Tests using Wollok-CLI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,7 +16,7 @@
 				"vscode-languageclient": "^8.0.2"
 			},
 			"engines": {
-				"vscode": "^1.67.0"
+				"vscode": "^1.71.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,0 +1,41 @@
+import * as path from 'path'
+import { commands, ExtensionContext, ShellExecution, Task, tasks, window, workspace } from 'vscode'
+
+
+export const subscribeWollokCommands = (context: ExtensionContext) => {
+  context.subscriptions.push(registerCLICommand('wollok.start.repl', startRepl))
+  context.subscriptions.push(registerCLICommand('wollok.run.allTests', runAllTests))
+}
+
+/**
+ * CLI Commands
+ */
+
+const runAllTests = () => wollokCLITask('run tests', `Wollok run all tests`, ['test'])
+
+const startRepl = () => {
+  const currentDocument = window.activeTextEditor.document
+  const currentFileName = path.basename(currentDocument.uri.path)
+  return wollokCLITask('repl', `Wollok Repl: ${currentFileName}`, ['repl', currentDocument.fileName])
+}
+
+/**
+ * Helpers
+ */
+
+const registerCLICommand = (command: string, taskBuilder: () => Task) =>
+  commands.registerCommand(command, () => tasks.executeTask(taskBuilder()))
+
+const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
+  const wollokCli = workspace.getConfiguration('wollokLinter').get('cli-path')
+  const folder = workspace.workspaceFolders[0]
+  const shellCommand = [wollokCli, ...cliCommands].join(' ')
+
+  return new Task(
+    { type: 'wollok', task },
+    folder,
+    name,
+    'wollok',
+    new ShellExecution(shellCommand)
+  )
+}

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import { commands, ExtensionContext, ShellExecution, Task, tasks, window, workspace } from 'vscode'
 
 
-export const subscribeWollokCommands = (context: ExtensionContext) => {
+export const subscribeWollokCommands = (context: ExtensionContext): void => {
   context.subscriptions.push(registerCLICommand('wollok.start.repl', startRepl))
   context.subscriptions.push(registerCLICommand('wollok.run.allTests', runAllTests))
 }
@@ -11,7 +11,7 @@ export const subscribeWollokCommands = (context: ExtensionContext) => {
  * CLI Commands
  */
 
-const runAllTests = () => wollokCLITask('run tests', `Wollok run all tests`, ['test'])
+const runAllTests = () => wollokCLITask('run tests', 'Wollok run all tests', ['test'])
 
 const startRepl = () => {
   const currentDocument = window.activeTextEditor.document

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -47,17 +47,18 @@ export function activate(context: ExtensionContext): void {
 
   context.subscriptions.push(
     commands.registerCommand('wollok.start.repl', () => {
+      const wollokCli = workspace.getConfiguration('wollokLinter').get('cli-path')
 
       const currentDocument = window.activeTextEditor.document
       const folder = workspace.workspaceFolders[0]
-      const currentFileName = currentDocument.uri.path.replace(`${folder.uri.path}/`, '')
+      const currentFileName = path.basename(currentDocument.uri.path)
 
       tasks.executeTask(new Task(
         { type: 'wollok', task: 'repl' },
         folder,
         `Wollok Repl: ${currentFileName}`,
         'wollok',
-        new ShellExecution(`wollok repl ${currentDocument.fileName}`)
+        new ShellExecution(`${wollokCli} repl ${currentDocument.fileName}`)
       ))
     })
   );

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,6 +63,21 @@ export function activate(context: ExtensionContext): void {
     })
   );
 
+  context.subscriptions.push(
+    commands.registerCommand('wollok.run.allTests', () => {
+      const wollokCli = workspace.getConfiguration('wollokLinter').get('cli-path')
+      const folder = workspace.workspaceFolders[0]
+
+      tasks.executeTask(new Task(
+        { type: 'wollok', task: 'run tests' },
+        folder,
+        `Wollok run all tests`,
+        'wollok',
+        new ShellExecution(`${wollokCli} test`)
+      ))
+    })
+  );
+
 
   // Create the language client and start the client.
   client = new LanguageClient(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,11 +4,13 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path'
-import { workspace, ExtensionContext } from 'vscode'
-import { LanguageClient,
+import { commands, ExtensionContext, ShellExecution, Task, tasks, window, workspace } from 'vscode'
+import {
+  LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  TransportKind } from 'vscode-languageclient/node'
+  TransportKind
+} from 'vscode-languageclient/node'
 
 let client: LanguageClient
 
@@ -42,6 +44,24 @@ export function activate(context: ExtensionContext): void {
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },
   }
+
+  context.subscriptions.push(
+    commands.registerCommand('wollok.start.repl', () => {
+
+      const currentDocument = window.activeTextEditor.document
+      const folder = workspace.workspaceFolders[0]
+      const currentFileName = currentDocument.uri.path.replace(`${folder.uri.path}/`, '')
+
+      tasks.executeTask(new Task(
+        { type: 'wollok', task: 'repl' },
+        folder,
+        `Wollok Repl: ${currentFileName}`,
+        'wollok',
+        new ShellExecution(`wollok repl ${currentDocument.fileName}`)
+      ))
+    })
+  );
+
 
   // Create the language client and start the client.
   client = new LanguageClient(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,13 +4,14 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path'
-import { commands, ExtensionContext, ShellExecution, Task, tasks, window, workspace } from 'vscode'
+import { ExtensionContext, workspace } from 'vscode'
 import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   TransportKind
 } from 'vscode-languageclient/node'
+import { subscribeWollokCommands } from './commands'
 
 let client: LanguageClient
 
@@ -45,38 +46,8 @@ export function activate(context: ExtensionContext): void {
     },
   }
 
-  context.subscriptions.push(
-    commands.registerCommand('wollok.start.repl', () => {
-      const wollokCli = workspace.getConfiguration('wollokLinter').get('cli-path')
-
-      const currentDocument = window.activeTextEditor.document
-      const folder = workspace.workspaceFolders[0]
-      const currentFileName = path.basename(currentDocument.uri.path)
-
-      tasks.executeTask(new Task(
-        { type: 'wollok', task: 'repl' },
-        folder,
-        `Wollok Repl: ${currentFileName}`,
-        'wollok',
-        new ShellExecution(`${wollokCli} repl ${currentDocument.fileName}`)
-      ))
-    })
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand('wollok.run.allTests', () => {
-      const wollokCli = workspace.getConfiguration('wollokLinter').get('cli-path')
-      const folder = workspace.workspaceFolders[0]
-
-      tasks.executeTask(new Task(
-        { type: 'wollok', task: 'run tests' },
-        folder,
-        `Wollok run all tests`,
-        'wollok',
-        new ShellExecution(`${wollokCli} test`)
-      ))
-    })
-  );
+  // Subscribe Wollok Commands
+  subscribeWollokCommands(context)
 
 
   // Create the language client and start the client.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,12 +5,10 @@
 
 import * as path from 'path'
 import { ExtensionContext, workspace } from 'vscode'
-import {
-  LanguageClient,
+import { LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  TransportKind
-} from 'vscode-languageclient/node'
+  TransportKind } from 'vscode-languageclient/node'
 import { subscribeWollokCommands } from './commands'
 
 let client: LanguageClient

--- a/package.json
+++ b/package.json
@@ -75,7 +75,14 @@
           "description": "Traces the communication between VS Code and the language server."
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "wollok.start.repl",
+        "title": "Start a new REPL session",
+        "category": "Wollok"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
         "command": "wollok.start.repl",
         "title": "Start a new REPL session",
         "category": "Wollok"
+      },
+      {
+        "command": "wollok.run.allTests",
+        "title": "Run all tests",
+        "when": "resourceExtname == .wtest",
+        "category": "Wollok"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
       "type": "object",
       "title": "Wollok LSP IDE",
       "properties": {
+        "wollokLinter.cli-path": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Path to Wollok-CLI."
+        },
         "wollokLinter.maxNumberOfProblems": {
           "scope": "resource",
           "type": "number",


### PR DESCRIPTION
Integración con [Wollok-ts-CLI](https://github.com/uqbar-project/wollok-ts-cli) para correr el REPL y los tests desde el VSCode.

- Se agregaron dos comandos de VSCode que terminan tirando código por consola.
- Se agrego una config para apuntar al ejecutable del CLI

Demo de cómo va quedando:

https://user-images.githubusercontent.com/4098184/196249853-edf3bd23-f239-4604-a56b-d12b7a3f89e8.mp4
