### PR TITLE
Validate all environment

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,11 +4,9 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path'
-import { ExtensionContext, workspace } from 'vscode'
+import { ExtensionContext, workspace, languages } from 'vscode'
 import { LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind } from 'vscode-languageclient/node'
+  LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node'
 import { subscribeWollokCommands } from './commands'
 
 let client: LanguageClient
@@ -47,7 +45,6 @@ export function activate(context: ExtensionContext): void {
   // Subscribe Wollok Commands
   subscribeWollokCommands(context)
 
-
   // Create the language client and start the client.
   client = new LanguageClient(
     'wollok-lsp-ide',
@@ -55,6 +52,14 @@ export function activate(context: ExtensionContext): void {
     serverOptions,
     clientOptions
   )
+
+  // Force document changes for first validation
+  workspace.findFiles('**/*.wlk').then(async uris => {
+    for (const uri of uris) {
+      const textDoc = await workspace.openTextDocument(uri)
+      languages.setTextDocumentLanguage(textDoc, 'wollok')
+    }
+  })
 
   // Start the client. This will also launch the server
   client.start()

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -32,12 +32,13 @@ const createDiagnostic = (textDocument: TextDocument, problem: Problem) => {
 
 // TODO: Refactor and move to utils
 const include = (node: Node, { position, textDocument: { uri } }: TextDocumentPositionParams) => {
+  if (!node.sourceFileName()) return false
+  if (node.kind === 'Package') {
+    return uri.includes(node.sourceFileName()!)
+  }
   const startLine = node.sourceMap?.start?.line
   const endLine = node.sourceMap?.end?.line
-  if (node.kind === 'Package') {
-    return uri === node.sourceFileName()
-  }
-  return node.sourceFileName() == uri && startLine && endLine &&
+  return uri.includes(node.sourceFileName()!) && startLine && endLine &&
     (startLine - 1 <= position.line && position.line <= endLine + 1 ||
       startLine - 1 == position.line && position.line == endLine + 1 &&
       (node?.sourceMap?.start?.offset || 0) <= position.character && position.character <= endLine
@@ -62,7 +63,7 @@ const createCompletionItem = (_position: Position) => (base: NodeCompletion): Co
 })
 
 function findFirstStableNode(node: Node): Node {
-  if (!node.problems) {
+  if (!node.problems || node.problems.length === 0) {
     return node
   }
   if (node.parent.kind === 'Environment') {


### PR DESCRIPTION
Debido a la lógica del [buildeo incremental](https://github.com/uqbar-project/wollok-ts/pull/140) que tenemos, recién se mandaba a buildear un archivo cuando se "activaba" (por ejemplo al abrirse y/o editarse).

#### Eso significa que según el orden en que mirabas los archivos tenían errores los `import`!

Acá se fuerza el buildeo de todos los archivos `.wlk` (que son los únicos que contienen definiciones) de todo el workspace al levantar el server.

------

También hay un fix del autocomplete que debuggeamos con @ivojawer