### PR TITLE
Progress report

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,11 +4,12 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path'
-import { ExtensionContext, workspace, languages } from 'vscode'
+import { ExtensionContext, workspace, languages, window, StatusBarAlignment } from 'vscode'
 import { LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  TransportKind } from 'vscode-languageclient/node'
+  TransportKind, 
+  WorkDoneProgress} from 'vscode-languageclient/node'
 import { subscribeWollokCommands } from './commands'
 import { allWollokFiles } from './utils'
 
@@ -58,6 +59,17 @@ export function activate(context: ExtensionContext): void {
 
   // Force first validation
   validateWorkspace()
+
+  const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left)
+
+  client.onProgress(WorkDoneProgress.type, 'wollok-build', progress => {
+    if (progress.kind === 'begin' || progress.kind === 'report') {
+      statusBarItem.text = '$(loading~spin) Wollok Building...'
+      statusBarItem.show()
+    } else {
+      statusBarItem.hide()
+    }
+  })
 
   // Force environment to restart
   const revalidateWorskpace = _event =>

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -8,8 +8,8 @@ import { ExtensionContext, workspace, languages, window, StatusBarAlignment } fr
 import { LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  TransportKind, 
-  WorkDoneProgress} from 'vscode-languageclient/node'
+  TransportKind,
+  WorkDoneProgress } from 'vscode-languageclient/node'
 import { subscribeWollokCommands } from './commands'
 import { allWollokFiles } from './utils'
 

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -43,7 +43,7 @@ async function testCommand(docUri: Uri, command: () => Task, expectedCommand: st
   await activate(docUri)
   const task = command()
   const execution = task.execution as ShellExecution
-  assert.equal(execution.commandLine, expectedCommand)
+  assert.ok(execution.commandLine.endsWith(expectedCommand))
 }
 
 function expectedPathByShell(cmd: Shell, originalPath: string ) {

--- a/server/src/environment-provider.ts
+++ b/server/src/environment-provider.ts
@@ -1,0 +1,48 @@
+import { Environment, buildEnvironment } from 'wollok-ts'
+import { wollokURI } from './utils/wollok'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { Connection, WorkDoneProgress } from 'vscode-languageserver'
+
+type EnvironmentSubscription = (environment: Environment) => any
+export class EnvironmentProvider {
+  environment: Environment | null = null
+  private subscriptions: EnvironmentSubscription[] = []
+
+  constructor(private connection: Connection) { }
+
+  withLatestEnvironment(cb: EnvironmentSubscription): void {
+    if(this.environment){
+      cb(this.environment)
+    } else {
+      this.subscriptions.push(cb)
+    }
+  }
+
+  rebuildTextDocument(document: TextDocument): void {
+    this.notifyBuild(() => {
+      const uri = wollokURI(document.uri)
+      const content = document.getText()
+      const file: { name: string, content: string } = {
+        name: uri,
+        content: content,
+      }
+      return buildEnvironment([file], this.environment || undefined)
+    })
+  }
+
+  resetEnvironment(): void {
+    this.notifyBuild(() => buildEnvironment([]))
+  }
+
+  private notifyBuild(build: () => Environment): void {
+    this.connection.sendProgress(WorkDoneProgress.type, 'wollok-build', { kind: 'begin', title: 'Wollok Building...' })
+    this.environment = build()
+    this.notify()
+    this.connection.sendProgress(WorkDoneProgress.type, 'wollok-build', { kind: 'end' })
+  }
+
+  private notify(): void {
+    this.subscriptions.forEach(subscription => subscription(this.environment!))
+    this.subscriptions = []
+  }
+}

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -12,7 +12,6 @@ import { documentSymbolsFor, workspaceSymbolsFor } from './symbols'
 import { TimeMeasurer } from './timeMeasurer'
 import { getNodesByPosition, getWollokFileExtension, nodeToLocation } from './utils/text-documents'
 import { isNodeURI, wollokURI, workspacePackage } from './utils/wollok'
-import { EnvironmentProvider } from './environment-provider'
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // INTERNAL FUNCTIONS

--- a/server/src/utils/progress-reporter.ts
+++ b/server/src/utils/progress-reporter.ts
@@ -1,4 +1,4 @@
-import { Connection, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } from 'vscode-languageserver';
+import { Connection, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } from 'vscode-languageserver'
 
 export class ProgressReporter {
   constructor(private connection: Connection, private process: { identifier: string, title: string }){}

--- a/server/src/utils/progress-reporter.ts
+++ b/server/src/utils/progress-reporter.ts
@@ -1,0 +1,21 @@
+import { Connection, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } from 'vscode-languageserver';
+
+export class ProgressReporter {
+  constructor(private connection: Connection, private process: { identifier: string, title: string }){}
+
+  begin(): Promise<void>{
+    return this.sendProgress({ kind: 'begin', title: this.process.title })
+  }
+
+  progress(percentage?: number): Promise<void>{
+    return this.sendProgress({ kind: 'report', percentage })
+  }
+
+  end(message?: string): Promise<void>{
+    return this.sendProgress({ kind: 'end', message })
+  }
+
+  sendProgress(payload: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd): Promise<void> {
+    return this.connection.sendProgress(WorkDoneProgress.type, this.process.identifier, payload)
+  }
+}


### PR DESCRIPTION
closes #71 

- Los comandos ahora esperan a que el environment este buildeado.
- Reporte de progreso en el client

Agregue dos `sendProgress`, _'wollok.request'_ lo deje por si en algun momento lo queremos usar pero ahora no se esta consumiendo desde el client