### PR TITLE
file icons + bump wollok-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "languages": [
       {
         "id": "wollok",
+        "icon": {
+          "dark": "./images/wollok.png",
+          "light": "./images/wollok.png"
+        },
         "aliases": [
           "Wollok",
           "wollok"
@@ -116,7 +120,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
-    "wollok-ts": "4.0.2"
+    "wollok-ts": "4.0.3"
   },
   "devDependencies": {
     "@types/expect": "^24.3.0",


### PR DESCRIPTION
https://code.visualstudio.com/api/extension-guides/file-icon-theme#language-default-icons


No se pudo implementar un icono especifico para cada tipo de archivo wollok porque para ello habria que crear un theme entero (implica overridear todos los iconos de todos los tipos de archivos en existencia)