### PR TITLE
Fix full path for files in problems tab

### DIFF
--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -59,7 +59,7 @@ const createDiagnostic = (textDocument: TextDocument, problem: Problem) => {
     range,
     code: problem.code,
     message: reportMessage(problem),
-    source: problem.node.sourceFileName,
+    source: '',
   } as Diagnostic
 }
 
@@ -76,7 +76,7 @@ function findFirstStableNode(node: Node): Node {
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // PUBLIC INTERFACE
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-const sendDiagnistics = (
+const sendDiagnostics = (
   connection: Connection,
   problems: List<Problem>,
   documents: TextDocument[],
@@ -102,7 +102,7 @@ export const validateTextDocument =
       const problems = validate(environment)
       timeMeasurer.addTime('build environment for file')
 
-      sendDiagnistics(connection, problems, allDocuments)
+      sendDiagnostics(connection, problems, allDocuments)
       timeMeasurer.addTime('validation time')
 
       timeMeasurer.finalReport()


### PR DESCRIPTION
VSC reporta los errores de esta manera:

![image](https://github.com/uqbar-project/wollok-lsp-ide/assets/4549002/5eae4264-df21-41b7-b0fb-32e8223b6c2f)

Nuestro code no es numérico, es un poco más copado, pero el path que se visualiza produce una línea muy larga:

![image](https://github.com/uqbar-project/wollok-lsp-ide/assets/4549002/96e9454f-54ec-48a0-97c5-af2f2aeeadb1)

Como en cambio se arma un árbol de issues, no hace falta mostrarlo para que además de lleve a la línea y la columna con el error:

![image](https://github.com/uqbar-project/wollok-lsp-ide/assets/4549002/7e8d7791-a171-4d14-8881-17c1762bdb1f)
