### PR TITLE
Open embedded browser for repl

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import * as vscode from 'vscode'
 import {
   commands,
   ExtensionContext,
@@ -52,11 +53,18 @@ export const runAllTests = (): Task =>
 export const startRepl = (): Task => {
   const currentDocument = window.activeTextEditor.document
   const currentFileName = path.basename(currentDocument.uri.path)
-  return wollokCLITask('repl', `Wollok Repl: ${currentFileName}`, [
+
+  const replTask = wollokCLITask('repl', `Wollok Repl: ${currentFileName}`, [
     'repl',
     fsToShell(currentDocument.uri.fsPath),
     '--skipValidations',
   ])
+
+  setTimeout(() => {
+    vscode.commands.executeCommand('simpleBrowser.show', 'http://localhost:3000/')
+  }, 1000)
+
+  return replTask
 }
 
 /**


### PR DESCRIPTION
Eso, ahora se puede abrir un navegador embebido:

![replDynamicDiagram](https://github.com/uqbar-project/wollok-lsp-ide/assets/4549002/3ca1f56f-e587-4cac-bdf5-53df832218d8)

Cosas que me gustaría agregar a futuro:

- que puedas configurar si querés abrir un diagrama dinámico cuando levantás el REPL
- que le puedas configurar si lo abrís externo o interno

Tuve que ponerle un setTimeout para que no abra la página en blanco. Es un hack, pero estoy dentro de un método que no es async...