### PR TITLE
Epic - Dynamic diagram on LSP IDE

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -61,6 +61,8 @@ const DYNAMIC_DIAGRAM_URI = 'http://localhost:3000/'
 export const startRepl = (): Task => {
   const currentDocument = window.activeTextEditor?.document
   const cliCommands = [`repl`, ...getFiles(currentDocument), '--skipValidations']
+  // Terminate previous tasks
+  vscode.commands.executeCommand('workbench.action.terminal.killAll')
   const replTask = wollokCLITask('repl', `Wollok Repl: ${getCurrentFileName(currentDocument)}`, cliCommands)
 
   const openDynamicDiagram = workspace.getConfiguration('wollokLSP').get('openDynamicDiagramOnRepl') as boolean

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -90,9 +90,10 @@ const registerCLICommand = (
   )
 
 const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
-  const wollokCli = unknownToShell(
-    workspace.getConfiguration('wollokLSP').get('cli-path'),
-  )
+  const wollokCliPath: string = workspace.getConfiguration('wollokLSP').get('cli-path')
+  // TODO: i18n - but it's in the server
+  if (!wollokCliPath) throw new Error('Missing configuration WollokLSP/cli-pat in order to run Wollok tasks')
+  const wollokCli = unknownToShell(wollokCliPath)
   const folder = workspace.workspaceFolders[0]
   const shellCommand = [
     wollokCli,

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -94,7 +94,7 @@ const registerCLICommand = (
 const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
   const wollokCliPath: string = workspace.getConfiguration('wollokLSP').get('cli-path')
   // TODO: i18n - but it's in the server
-  if (!wollokCliPath) throw new Error('Missing configuration WollokLSP/cli-pat in order to run Wollok tasks')
+  if (!wollokCliPath) throw new Error('Missing configuration WollokLSP/cli-path in order to run Wollok tasks')
   const wollokCli = unknownToShell(wollokCliPath)
   const folder = workspace.workspaceFolders[0]
   const shellCommand = [

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -50,20 +50,19 @@ export const runAllTests = (): Task =>
     '--skipValidations',
   ])
 
+const getCurrentFileName = (document: vscode.TextDocument | undefined) =>
+  document ? path.basename(document.uri.path) : 'Synthetic File'
+
+const getFiles = (document: vscode.TextDocument | undefined) =>
+  document ? [fsToShell(document.uri.fsPath)] : []
+
 export const startRepl = (): Task => {
-  const currentDocument = window.activeTextEditor.document
-  const currentFileName = path.basename(currentDocument.uri.path)
-
-  const replTask = wollokCLITask('repl', `Wollok Repl: ${currentFileName}`, [
-    'repl',
-    fsToShell(currentDocument.uri.fsPath),
-    '--skipValidations',
-  ])
-
+  const currentDocument = window.activeTextEditor?.document
+  const cliCommands = [`repl`, ...getFiles(currentDocument), '--skipValidations']
+  const replTask = wollokCLITask('repl', `Wollok Repl: ${getCurrentFileName(currentDocument)}`, cliCommands)
   setTimeout(() => {
     vscode.commands.executeCommand('simpleBrowser.show', 'http://localhost:3000/')
   }, 1000)
-
   return replTask
 }
 

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -60,15 +60,17 @@ const DYNAMIC_DIAGRAM_URI = 'http://localhost:3000/'
 
 export const startRepl = (): Task => {
   const currentDocument = window.activeTextEditor?.document
-  const cliCommands = [`repl`, ...getFiles(currentDocument), '--skipValidations']
+  const wollokLSPConfiguration = workspace.getConfiguration('wollokLSP')
+  const dynamicDiagramDarkMode = wollokLSPConfiguration.get('dynamicDiagramDarkMode') ?? false
+  const cliCommands = [`repl`, ...getFiles(currentDocument), '--skipValidations', dynamicDiagramDarkMode ? '--darkMode' : '']
   // Terminate previous tasks
   vscode.commands.executeCommand('workbench.action.terminal.killAll')
   const replTask = wollokCLITask('repl', `Wollok Repl: ${getCurrentFileName(currentDocument)}`, cliCommands)
 
-  const openDynamicDiagram = workspace.getConfiguration('wollokLSP').get('openDynamicDiagramOnRepl') as boolean
+  const openDynamicDiagram = wollokLSPConfiguration.get('openDynamicDiagramOnRepl') as boolean
   if (openDynamicDiagram) {
     setTimeout(() => {
-      const openInternalDynamicDiagram = workspace.getConfiguration('wollokLSP').get('openInternalDynamicDiagram') as boolean
+      const openInternalDynamicDiagram = wollokLSPConfiguration.get('openInternalDynamicDiagram') as boolean
       if (openInternalDynamicDiagram) {
         vscode.commands.executeCommand('simpleBrowser.show', DYNAMIC_DIAGRAM_URI)
       } else {

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -1,13 +1,24 @@
 import * as assert from 'assert'
 import * as sinon from 'sinon'
-import { ShellExecution, Task, Uri, env } from 'vscode'
+import { ShellExecution, Task, Uri, env, workspace } from 'vscode'
 import { runAllTests, runProgram, runTests, startRepl } from '../commands'
 import { activate, getDocumentURI, getFolderURI } from './helper'
 import { toPosix, toWin, Shell } from '../platform-string-utils'
+import { afterEach, beforeEach } from 'mocha'
 
 suite('Should run commands', () => {
   const folderURI = getFolderURI()
   const pepitaURI = getDocumentURI('pepita.wlk')
+
+  beforeEach(() => {
+    sinon.stub(workspace, 'getConfiguration').value((_configuration: string) => ({
+      get: (_value: string) => '/usr/bin/wollok-ts-cli',
+    }))
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
 
   test('run program', async () => {
     await onWindowsBash(() =>

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -82,7 +82,7 @@ suite('Should run commands', () => {
         startRepl,
         ` repl ${toPosix(
           pepitaURI.fsPath,
-        )} --skipValidations -p ${expectedPathByShell(
+        )} --skipValidations --darkMode -p ${expectedPathByShell(
           'bash',
           folderURI.fsPath,
         )}`,

--- a/package.json
+++ b/package.json
@@ -81,20 +81,6 @@
           "description": "Controls the maximum number of problems produced by the server.",
           "order": 2
         },
-        "wollokLSP.openDynamicDiagramOnRepl": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Opens the dynamic diagram when running the REPL.",
-          "order": 3
-        },
-        "wollokLSP.openInternalDynamicDiagram": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "If true, opens an internal dynamic diagram inside Wollok IDE. If false, it will open a new external browser.",
-          "order": 4
-        },
         "wollokLSP.trace.server": {
           "scope": "window",
           "type": "string",
@@ -105,7 +91,28 @@
           ],
           "default": "off",
           "description": "Traces the communication between VS Code and the language server.",
+          "order": 3
+        },
+        "wollokLSP.openDynamicDiagramOnRepl": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Opens the dynamic diagram when running the REPL.",
+          "order": 4
+        },
+        "wollokLSP.openInternalDynamicDiagram": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "If true, opens an internal dynamic diagram inside Wollok IDE. If false, it will open a new external browser.",
           "order": 5
+        },
+        "wollokLSP.dynamicDiagramDarkMode": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "If true, opens dynamic diagram in Dark Mode. Otherwise, it uses Light Mode.",
+          "order": 6
         }
       }
     },
@@ -113,7 +120,7 @@
       {
         "command": "wollok.start.repl",
         "title": "Start a new REPL session",
-        "category": "Wollok"
+                "category": "Wollok"
       },
       {
         "command": "wollok.run.allTests",

--- a/package.json
+++ b/package.json
@@ -56,18 +56,13 @@
       "type": "object",
       "title": "Wollok LSP IDE",
       "properties": {
-        "wollokLinter.cli-path": {
+        "wollokLSP.cli-path": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to Wollok-CLI."
+          "description": "Path to Wollok-CLI.",
+          "order": 0
         },
-        "wollokLinter.maxNumberOfProblems": {
-          "scope": "resource",
-          "type": "number",
-          "default": 100,
-          "description": "Controls the maximum number of problems produced by the server."
-        },
-        "wollokLinter.language": {
+        "wollokLSP.language": {
           "scope": "resource",
           "type": "string",
           "enum": [
@@ -76,9 +71,31 @@
             "Based on Local Environment"
           ],
           "default": "Based on Local Environment",
-          "description": "Language used while reporting linter errors and warnings."
+          "description": "Language used while reporting linter errors and warnings.",
+          "order": 1
         },
-        "wollokLinter.trace.server": {
+        "wollokLSP.maxNumberOfProblems": {
+          "scope": "resource",
+          "type": "number",
+          "default": 100,
+          "description": "Controls the maximum number of problems produced by the server.",
+          "order": 2
+        },
+        "wollokLSP.openDynamicDiagramOnRepl": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Opens the dynamic diagram when running the REPL.",
+          "order": 3
+        },
+        "wollokLSP.openInternalDynamicDiagram": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "If true, opens an internal dynamic diagram inside Wollok IDE. If false, it will open a new external browser.",
+          "order": 4
+        },
+        "wollokLSP.trace.server": {
           "scope": "window",
           "type": "string",
           "enum": [
@@ -87,7 +104,8 @@
             "verbose"
           ],
           "default": "off",
-          "description": "Traces the communication between VS Code and the language server."
+          "description": "Traces the communication between VS Code and the language server.",
+          "order": 5
         }
       }
     },

--- a/server/src/functionalities/reporter.ts
+++ b/server/src/functionalities/reporter.ts
@@ -5,11 +5,11 @@ import { lang } from '../settings'
 // VALIDATION MESSAGES DEFINITION
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
-type ValidationMessage = { [key: string]: string }
+type Message = { [key: string]: string }
 
 const FAILURE = 'failure'
 
-const validationMessagesEn: ValidationMessage = {
+const validationMessagesEn: Message = {
   nameShouldBeginWithLowercase: 'The name {0} must start with lowercase',
   nameShouldBeginWithUppercase: 'The name {0} must start with uppercase',
   nameShouldNotBeKeyword:
@@ -95,7 +95,7 @@ const validationMessagesEn: ValidationMessage = {
   [FAILURE]: 'Rule failure: ',
 }
 
-const validationMessagesEs: ValidationMessage = {
+const validationMessagesEs: Message = {
   nameShouldBeginWithLowercase:
     'El nombre {0} debe comenzar con min\u00FAsculas',
   nameShouldBeginWithUppercase:
@@ -195,9 +195,25 @@ const validationMessagesEs: ValidationMessage = {
   [FAILURE]: 'La siguiente regla fall\u00F3: ',
 }
 
-const validationMessages: { [key: string]: ValidationMessage } = {
-  en: validationMessagesEn,
-  es: validationMessagesEs,
+const MISSING_WOLLOK_TS_CLI = 'missing_wollok_ts_cli'
+
+const lspMessagesEn = {
+  [MISSING_WOLLOK_TS_CLI]: 'Missing configuration WollokLSP/cli-pat in order to run Wollok tasks',
+}
+
+const lspMessagesEs = {
+  [MISSING_WOLLOK_TS_CLI]: 'Falta la configuración WollokLSP/cli-path para poder ejecutar tareas de Wollok',
+}
+
+const messages: { [key: string]: Message } = {
+  en: {
+    ...validationMessagesEn,
+    ...lspMessagesEn,
+  },
+  es: {
+    ...validationMessagesEs,
+    ...lspMessagesEs,
+  },
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
@@ -225,14 +241,14 @@ const interpolateValidationMessage = (message: string, ...values: string[]) =>
     return values[index] || ''
   })
 
-const getBasicMessage = (problem: Problem) =>
-  validationI18nized()[problem.code] || convertToHumanReadable(problem.code)
-
-const validationI18nized = () => validationMessages[lang()] as ValidationMessage
+const validationI18nized = () => messages[lang()] as Message
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // PUBLIC INTERFACE
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
-export const reportMessage = (problem: Problem): string =>
-  interpolateValidationMessage(getBasicMessage(problem), ...problem.values)
+export const reportValidationMessage = (problem: Problem): string =>
+  getMessage(problem.code, problem.values.concat())
+
+export const getMessage = (message: string, values: string[]): string =>
+  interpolateValidationMessage(validationI18nized()[message] || convertToHumanReadable(message), ...values)

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -25,7 +25,7 @@ import {
   getTestCodeLenses,
 } from './functionalities/code-lens'
 import { getNodeDefinition } from './functionalities/definition'
-import { reportMessage } from './functionalities/reporter'
+import { reportValidationMessage } from './functionalities/reporter'
 import { updateDocumentSettings } from './settings'
 import {
   documentSymbolsFor,
@@ -58,7 +58,7 @@ const createDiagnostic = (textDocument: TextDocument, problem: Problem) => {
     severity: buildSeverity(problem),
     range,
     code: problem.code,
-    message: reportMessage(problem),
+    message: reportValidationMessage(problem),
     source: '',
   } as Diagnostic
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,7 +17,7 @@ import {
   validateTextDocument,
   workspaceSymbols,
 } from './linter'
-import { initializeSettings, WollokLinterSettings } from './settings'
+import { initializeSettings, WollokLSPSettings } from './settings'
 import { templates } from './functionalities/autocomplete/templates'
 import { EnvironmentProvider } from './utils/vm/environment-provider'
 
@@ -77,27 +77,12 @@ connection.onInitialized(() => {
 })
 
 // Cache the settings of all open documents
-const documentSettings: Map<string, Thenable<WollokLinterSettings>> = new Map()
+const documentSettings: Map<string, Thenable<WollokLSPSettings>> = new Map()
 
 connection.onDidChangeConfiguration(() => {
   // Revalidate all open text documents
   documents.all().forEach(validateTextDocument(connection, documents.all()))
 })
-
-// function getDocumentSettings(resource: string): Thenable<ExampleSettings> {
-//   if (!hasConfigurationCapability) {
-//     return Promise.resolve(globalSettings)
-//   }
-//   let result = documentSettings.get(resource)
-//   if (!result) {
-//     result = connection.workspace.getConfiguration({
-//       scopeUri: resource,
-//       section: 'languageServerExample',
-//     })
-//     documentSettings.set(resource, result)
-//   }
-//   return result
-// }
 
 // Only keep settings for open documents
 documents.onDidClose((e) => {

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -1,8 +1,10 @@
 import { Connection } from 'vscode-languageserver/node'
 
-export interface WollokLinterSettings {
+export interface WollokLSPSettings {
   maxNumberOfProblems: number
-  language: string
+  language: string,
+  openDynamicDiagramOnRepl: boolean,
+  openInternalDynamicDiagram: boolean,
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
@@ -18,12 +20,14 @@ const envLang = () => {
   return fullLanguage ? fullLanguage.substring(0, 2) : SPANISH
 }
 
-const defaultSettings: WollokLinterSettings = {
+const defaultSettings: WollokLSPSettings = {
   maxNumberOfProblems: 1000,
   language: envLang(),
+  openDynamicDiagramOnRepl: true,
+  openInternalDynamicDiagram: true,
 }
 
-let globalSettings: WollokLinterSettings = defaultSettings
+let globalSettings: WollokLSPSettings = defaultSettings
 
 const languageDescription: { [key: string]: string } = {
   Spanish: SPANISH,
@@ -38,8 +42,8 @@ export const updateDocumentSettings = async (
 ): Promise<void> => {
   globalSettings =
     ((await connection.workspace.getConfiguration({
-      section: 'wollokLinter',
-    })) as WollokLinterSettings) || defaultSettings
+      section: 'wollokLSP',
+    })) as WollokLSPSettings) || defaultSettings
 }
 
 export const initializeSettings = async (

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -5,6 +5,7 @@ export interface WollokLSPSettings {
   language: string,
   openDynamicDiagramOnRepl: boolean,
   openInternalDynamicDiagram: boolean,
+  dynamicDiagramDarkMode: boolean,
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
@@ -25,6 +26,7 @@ const defaultSettings: WollokLSPSettings = {
   language: envLang(),
   openDynamicDiagramOnRepl: true,
   openInternalDynamicDiagram: true,
+  dynamicDiagramDarkMode: true,
 }
 
 let globalSettings: WollokLSPSettings = defaultSettings


### PR DESCRIPTION
En esta épica metí algunas cosas que teníamos del lado del IDE LSP

- [x] [Mostrar un mensaje de error representativo si no tenés configurado el wollok-ts-cli](https://github.com/uqbar-project/wollok-lsp-ide/issues/101)
- [X] Si arrancás un archivo que no es wlk te tira un error al abrir el document
- [x] [Queda siempre fijo el archivo que abrís cuando levantás el REPL](https://github.com/uqbar-project/wollok-lsp-ide/issues/98)
- [x] Que se pueda configurar si querés tener dark mode / light mode
- [X] Que se pueda configurar si querés abrir un diagrama dinámico cuando levantás el REPL (lsp-ide) (no tan urgente)
- [X] Que se pueda configurar si querés abrir un navegador interno o externo (lsp-ide)

> Por ahora decidí pausar configurar colores para dark mode / light mode en objetos custom/del lenguaje. La configuración en sí es una pavada agregarla, pero es medio una paja tener que pasarla al wollok-ts-cli como parámetros dentro de una línea de comandos. 

