### PR TITLE
Publishing marketplace

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,22 +1,24 @@
-.vscode/**
-.vscode-test/**
 .github/**
 .husky/**
+.vscode/**
+.vscode-test/**
 **/*.ts
 **/*.map
 .gitignore
 **/tsconfig.json
 **/tsconfig.base.json
 contributing.md
-.travis.yml
-**/node_modules/**
+client/out/test/**
+client/out/testFixture/**
+server/out/test/**
+# client/node_modules/**
 # !client/node_modules/vscode-jsonrpc/**
 # !client/node_modules/vscode-languageclient/**
 # !client/node_modules/vscode-languageserver-protocol/**
 # !client/node_modules/vscode-languageserver-types/**
 # !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 # !client/node_modules/{semver,lru-cache,yallist}/**
-**/test/**
+# **/node_modules/**
 **/.mocharc.js
 **/.prettierrc
 **/.eslintrc

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,27 +1,33 @@
+# development folders
 .github/**
 .husky/**
 .vscode/**
 .vscode-test/**
-**/*.ts
-**/*.map
 .gitignore
 **/tsconfig.json
 **/tsconfig.base.json
-contributing.md
-client/out/test/**
-client/out/testFixture/**
-server/out/test/**
-# client/node_modules/**
-# !client/node_modules/vscode-jsonrpc/**
-# !client/node_modules/vscode-languageclient/**
-# !client/node_modules/vscode-languageserver-protocol/**
-# !client/node_modules/vscode-languageserver-types/**
-# !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
-# !client/node_modules/{semver,lru-cache,yallist}/**
-# **/node_modules/**
+**/node_modules/**
 **/.mocharc.js
 **/.prettierrc
 **/.eslintrc
 **/.gitignore
 **/scripts
-**/testFixture/*
+contributing.md
+
+# ts files are deployed as compiled js
+**/*.ts
+**/*.map
+
+# no tests needed
+client/out/test/**
+client/out/testFixture/**
+server/out/test/**
+
+# node_modules, except by vscode and needed dependencies
+client/node_modules/**
+!client/node_modules/vscode-jsonrpc/**
+!client/node_modules/vscode-languageclient/**
+!client/node_modules/vscode-languageserver-protocol/**
+!client/node_modules/vscode-languageserver-types/**
+!client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
+!client/node_modules/{semver,lru-cache,yallist}/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,7 @@
 .vscode/**
+.vscode-test/**
+.github/**
+.husky/**
 **/*.ts
 **/*.map
 .gitignore
@@ -6,10 +9,17 @@
 **/tsconfig.base.json
 contributing.md
 .travis.yml
-client/node_modules/**
-!client/node_modules/vscode-jsonrpc/**
-!client/node_modules/vscode-languageclient/**
-!client/node_modules/vscode-languageserver-protocol/**
-!client/node_modules/vscode-languageserver-types/**
-!client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
-!client/node_modules/{semver,lru-cache,yallist}/**
+**/node_modules/**
+# !client/node_modules/vscode-jsonrpc/**
+# !client/node_modules/vscode-languageclient/**
+# !client/node_modules/vscode-languageserver-protocol/**
+# !client/node_modules/vscode-languageserver-types/**
+# !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
+# !client/node_modules/{semver,lru-cache,yallist}/**
+**/test/**
+**/.mocharc.js
+**/.prettierrc
+**/.eslintrc
+**/.gitignore
+**/scripts
+**/testFixture/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.1
+
+- Upgrade Wollok-TS 4.0.5 ⬆️
+- Published in Marketplace 🌈
+- Dynamic diagram enhancements 🔵
+- Autocomplete enhancements ✍🏼
+- Fix REPL command sessions 🐛
+
 ## v0.0.6
 
 ### Using wollok-ts v4.0.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Wollok IDE
 
-[![Node.js CI](https://github.com/uqbar-project/wollok-lsp-ide/actions/workflows/node.js.yml/badge.svg)](https://github.com/uqbar-project/wollok-lsp-ide/actions/workflows/node.js.yml)
 
 Starting from [LSP sample code](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide) for Visual Studio Code, we developed a couple of tools for Wollok using Language Server Protocol (for Visual Studio Code, IntelliJ, Eclipse, Atom, etc.)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "wollok-lsp-ide",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-lsp-ide",
-      "version": "0.0.7",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "dependencies": {
-        "wollok-ts": "4.0.4"
+        "wollok-ts": "4.0.5"
       },
       "devDependencies": {
         "@types/expect": "^24.3.0",
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/wollok-ts": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.4.tgz",
-      "integrity": "sha512-ncuryLXHCYEexw8tjmmxDqPnt1xaM/+EHYkPRXWHad0FTWUxX+lf6QQq0fT3sG/eWWmsMX6ULkPUe/14nPjKTA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
+      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
       "dependencies": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",
@@ -7484,9 +7484,9 @@
       }
     },
     "wollok-ts": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.4.tgz",
-      "integrity": "sha512-ncuryLXHCYEexw8tjmmxDqPnt1xaM/+EHYkPRXWHad0FTWUxX+lf6QQq0fT3sG/eWWmsMX6ULkPUe/14nPjKTA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
+      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
       "requires": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "icon": "images/wollokLinterLogo.png",
   "engines": {
-    "vscode": "^1.71.0"
+    "vscode": "^1.83.0"
   },
   "activationEvents": [
     "onLanguage:wollok"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Uqbar Foundation",
   "license": "LGPL-3.0",
   "publisher": "uqbar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uqbar-project/wollok-lsp-ide"
@@ -14,7 +14,7 @@
     "Programming Languages"
   ],
   "keywords": [
-    "linter validator wollok oop educative objects learning"
+    "ide wollok oop educative objects learning"
   ],
   "icon": "images/wollokLinterLogo.png",
   "engines": {


### PR DESCRIPTION
Estos fueron los cambios que se generaron para publicar en el marketplace:

- después de varios intentos fallidos de publicar la extensión, se buscó en [los issues del Marketplace](https://github.com/microsoft/vsmarketplace/issues?q=is%3Aissue+TF400898+is%3Aclosed), incluso en los cerrados y saltó que el problema era por los keywords (tags) que debe ser menor a 50 caracteres (algo que deben haber agregado hace poco porque el highlighter los supera). También hay que tener `displayName` (cosa que ya lo cumplía), y [ciertos requisitos como usar png o svg seguros, y links https](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)
- también se configuró en `.vscodeignore` la lista de archivos que van a empaquetarse dentro del VSIX
- se agregó el CHANGELOG la versión 0.1.1 con los últimos cambios
- a futuro en el README podríamos agregar contributors, badges de cobertura, badges de build, etc.
