### PR TITLE
Fix run test para Windows

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -41,7 +41,7 @@ export const runProgram = (fqn: string): Task =>
 export const runTests = (filter: string): Task =>
   wollokCLITask('run tests', 'Wollok run tests', [
     'test',
-    `'${asShellString(filter)}'`,
+    `${asShellString(filter)}`,
     '--skipValidations',
   ])
 
@@ -101,6 +101,7 @@ const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
     vscode.commands.executeCommand('workbench.action.openSettings', wollokLSPExtensionCode)
     throw new Error('Missing configuration WollokLSP/cli-path. Set the path where wollok-ts-cli is located in order to run Wollok tasks')
   }
+
   const wollokCli = unknownToShell(wollokCliPath)
   const folder = workspace.workspaceFolders[0]
   const shellCommand = [

--- a/client/src/platform-string-utils.ts
+++ b/client/src/platform-string-utils.ts
@@ -2,13 +2,13 @@ import path = require('path')
 import { replaceAll } from './utils'
 import { env } from 'vscode'
 
-export type Shell = 'bash' | 'cmd' | 'powershell' | 'zsh'
+export type Shell = 'bash' | 'cmd' | 'pwsh' | 'zsh'
 
 export function asShellString(string: string): string {
   if (activeShell() === 'cmd') {
-    return replaceAll(string, '"', '\\"')
+    return `"${replaceAll(string, '"', '')}"`
   }
-  return string
+  return `'${string}'`
 }
 
 export function asShellPath(abstractPath: string[]): string {
@@ -58,6 +58,6 @@ export function transformSeparators(
  * @default 'bash'
  */
 function activeShell(): Shell {
-  const shells = ['cmd', 'powershell', 'bash', 'zsh'] as const
+  const shells = ['cmd', 'pwsh', 'bash', 'zsh'] as const
   return shells.find((shell) => env.shell.includes(shell)) || 'bash'
 }

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -35,7 +35,6 @@ suite('Should run commands', () => {
 
   suite('run tests', () => {
     const testFQN = 'tests."tests de pepita"."something"'
-    const testFQNCMD = 'tests.\\"tests de pepita\\".\\"something\\"'
 
     async function runCommandOnPlatform(
       platform: string,
@@ -44,10 +43,11 @@ suite('Should run commands', () => {
     ) {
       sinon.stub(process, 'platform').value(platform)
       sinon.stub(env, 'shell').value(shell)
+      const separator = shell == 'cmd' ? '"' : '\''
       await testCommand(
         pepitaURI,
         () => runTests(testFQN),
-        ` test '${expectedCommand}' --skipValidations -p ${expectedPathByShell(
+        ` test ${separator}${expectedCommand}${separator} --skipValidations -p ${expectedPathByShell(
           shell,
           folderURI.fsPath,
         )}`,
@@ -57,7 +57,8 @@ suite('Should run commands', () => {
 
     test('on Linux', () => runCommandOnPlatform('linux', 'bash', testFQN))
     test('on Mac', () => runCommandOnPlatform('darwin', 'bash', testFQN))
-    test('on Windows', () => runCommandOnPlatform('win32', 'cmd', testFQNCMD))
+    test('on Windows with Command', () => runCommandOnPlatform('win32', 'cmd', 'tests.tests de pepita.something'))
+    test('on Windows with Powershell', () => runCommandOnPlatform('win32', 'pwsh', testFQN))
     test('on Windows with Bash', () =>
       runCommandOnPlatform('win32', 'bash', testFQN))
   })
@@ -99,7 +100,7 @@ async function testCommand(
   await activate(docUri)
   const task = command()
   const execution = task.execution as ShellExecution
-  assert.ok(execution.commandLine.endsWith(expectedCommand))
+  assert.ok(execution.commandLine.endsWith(expectedCommand), `[NOT MATCH]: [${execution.commandLine}] vs. [${expectedCommand}]`)
 }
 
 function expectedPathByShell(cmd: Shell, originalPath: string) {


### PR DESCRIPTION
Como parte de la solución para [este issue](https://github.com/uqbar-project/wollok-ts-cli/issues/109) sale este fix para ejecutar tests en Windows con cmd, Powershell y bash

- se corrigió el nombre del ejecutable de Powershell
- se agregó un test unitario para el Powershell y se corrigió el test para cmd (no es la gran cosa pero al menos lo estamos validando)
- y soportamos los tres tipos de terminal

