### PR TITLE
Failed build when starting the LSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
     },
     "../wollok-ts": {
       "version": "4.0.6",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",
@@ -1022,6 +1023,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
       "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
+    },
+    "node_modules/@types/parsimmon": {
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.9.tgz",
+      "integrity": "sha512-O2M2x1w+m7gWLen8i5DOy6tWRnbRcsW6Pke3j3HAsJUrPb4g0MgjksIUm2aqUtCYxy7Qjr3CzjjwQBzhiGn46A=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -3119,6 +3125,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -4533,6 +4544,28 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parsimmon": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
+      "integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw=="
+    },
+    "node_modules/partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "dependencies": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "node_modules/partial.lenses.validation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses.validation/-/partial.lenses.validation-2.0.0.tgz",
+      "integrity": "sha512-NBZhmrunQWc4Ih5pJGYPHCEJfjIITPEkYn0Z6YB8qmW0iN4ZeqN0eZTWAPAH8MxjsEGx3G+8xnTMsEHbzy0k/A==",
+      "dependencies": {
+        "infestines": "^0.4.10",
+        "partial.lenses": "^14.0.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -4707,6 +4740,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier-printer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-printer/-/prettier-printer-1.1.4.tgz",
+      "integrity": "sha512-gQIWF7PKVknRcMoZ4Lsqj2icc97W+Q9JTa7xQgNem07yZFzOimUPq50N5oRfKkSRBZT8QqrVW1IBEMBPWqjBgQ==",
+      "dependencies": {
+        "infestines": "^0.4.11",
+        "partial.lenses.validation": "^2.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -5719,6 +5761,11 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "node_modules/unraw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -5770,6 +5817,18 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -6740,6 +6799,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
       "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
+    },
+    "@types/parsimmon": {
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.9.tgz",
+      "integrity": "sha512-O2M2x1w+m7gWLen8i5DOy6tWRnbRcsW6Pke3j3HAsJUrPb4g0MgjksIUm2aqUtCYxy7Qjr3CzjjwQBzhiGn46A=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -8135,6 +8199,11 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
+    "infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
     "inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -9178,6 +9247,28 @@
         "parse5": "^7.0.0"
       }
     },
+    "parsimmon": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
+      "integrity": "sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw=="
+    },
+    "partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "requires": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "partial.lenses.validation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses.validation/-/partial.lenses.validation-2.0.0.tgz",
+      "integrity": "sha512-NBZhmrunQWc4Ih5pJGYPHCEJfjIITPEkYn0Z6YB8qmW0iN4ZeqN0eZTWAPAH8MxjsEGx3G+8xnTMsEHbzy0k/A==",
+      "requires": {
+        "infestines": "^0.4.10",
+        "partial.lenses": "^14.0.0"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -9299,6 +9390,15 @@
     "prelude-ls": {
       "version": "1.2.1",
       "dev": true
+    },
+    "prettier-printer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-printer/-/prettier-printer-1.1.4.tgz",
+      "integrity": "sha512-gQIWF7PKVknRcMoZ4Lsqj2icc97W+Q9JTa7xQgNem07yZFzOimUPq50N5oRfKkSRBZT8QqrVW1IBEMBPWqjBgQ==",
+      "requires": {
+        "infestines": "^0.4.11",
+        "partial.lenses.validation": "^2.0.0"
+      }
     },
     "pretty-format": {
       "version": "29.1.2",
@@ -9982,6 +10082,11 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "unraw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+    },
     "update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -10014,6 +10119,11 @@
       "dev": true,
       "optional": true
     },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -10038,33 +10148,11 @@
       "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.8.tgz",
       "integrity": "sha512-EE24DPvGP20zTLFQgAG4vY8wIcuVay+gN0NeYtgyXl06Fwi6o98HUOSjEKP13AiAlAzkKq2MgF/4mfwaKoFm9w==",
       "requires": {
-        "@types/chai": "^4.3.9",
-        "@types/mocha": "^10.0.3",
-        "@types/node": "^18.14.1",
         "@types/parsimmon": "^1.10.8",
-        "@types/sinon": "^10.0.20",
-        "@types/sinon-chai": "^3.2.11",
-        "@types/uuid": "^9.0.6",
-        "@types/yargs": "^17.0.22",
-        "@typescript-eslint/eslint-plugin": "^5.53.0",
-        "@typescript-eslint/parser": "^5.53.0",
-        "chai": "^4.3.7",
-        "chalk": "^5.2.0",
-        "dedent": "^1.5.1",
-        "eslint": "^8.35.0",
-        "globby": "^11.1.0",
-        "mocha": "^10.2.0",
-        "nyc": "^15.1.0",
         "parsimmon": "^1.18.1",
         "prettier-printer": "^1.1.4",
-        "simple-git": "^3.20.0",
-        "sinon": "17.0.0",
-        "sinon-chai": "^3.7.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.9.5",
         "unraw": "^3.0.0",
-        "uuid": "^9.0.1",
-        "yargs": "^17.7.2"
+        "uuid": "^9.0.1"
       }
     },
     "word-wrap": {

--- a/server/src/functionalities/code-lens.ts
+++ b/server/src/functionalities/code-lens.ts
@@ -1,9 +1,24 @@
-import { CodeLens, Position, Range } from 'vscode-languageserver'
-import { Describe, Node, Package, Test, Program } from 'wollok-ts'
+import { CodeLens, CodeLensParams, Position, Range } from 'vscode-languageserver'
+import { Describe, Node, Package, Test, Program, Environment } from 'wollok-ts'
 import { is } from 'wollok-ts/dist/extensions'
-import { toVSCRange } from '../utils/text-documents'
+import { getWollokFileExtension, packageFromURI, toVSCRange } from '../utils/text-documents'
 import { fqnRelativeToPackage } from '../utils/vm/wollok'
 
+
+export const codeLenses = (environment: Environment) => (params: CodeLensParams): CodeLens[] | null => {
+  const fileExtension = getWollokFileExtension(params.textDocument.uri)
+  const file = packageFromURI(params.textDocument.uri, environment)
+  if (!file) return null
+
+  switch (fileExtension) {
+    case 'wpgm':
+      return getProgramCodeLenses(file)
+    case 'wtest':
+      return getTestCodeLenses(file)
+    default:
+      return null
+  }
+}
 
 export const getProgramCodeLenses = (file: Package): CodeLens[] =>
   file.members.filter(is(Program)).map(program => ({

--- a/server/src/functionalities/hover.ts
+++ b/server/src/functionalities/hover.ts
@@ -1,17 +1,16 @@
 import { Hover, HoverParams } from 'vscode-languageserver'
 import { Body, Environment, print } from 'wollok-ts'
 import { cursorNode, toVSCRange } from '../utils/text-documents'
+import { logger } from '../utils/logger'
 
 type TypeDescriptionResponse = Hover | null
 
 export const typeDescriptionOnHover = (environment: Environment) => (params: HoverParams): TypeDescriptionResponse => {
-  let node = cursorNode(environment, params.position, params.textDocument)
-
-  if(node.is(Body)){
-    node = node.parent
-  }
-
-  try{
+  try {
+    let node = cursorNode(environment, params.position, params.textDocument)
+    if(node.is(Body)){
+      node = node.parent
+    }
 
     return {
       contents: [
@@ -26,7 +25,8 @@ export const typeDescriptionOnHover = (environment: Environment) => (params: Hov
       ],
       range: node.sourceMap ? toVSCRange(node.sourceMap) : undefined,
     }
-  } catch {
+  } catch(e) {
+    logger.error('Failed to get type description', e)
     return null
   }
 }

--- a/server/src/functionalities/symbols.ts
+++ b/server/src/functionalities/symbols.ts
@@ -2,6 +2,7 @@ import { DocumentSymbol, DocumentSymbolParams, SymbolKind, WorkspaceSymbol, Work
 import { Environment, Field, Method, Module, Node, Package, Program, Test, Variable } from 'wollok-ts'
 import { packageFromURI, toVSCRange } from '../utils/text-documents'
 import { workspacePackage } from '../utils/vm/wollok'
+import { logger } from '../utils/logger'
 
 type Symbolyzable = Program | Test | Module | Variable | Field | Method | Test
 
@@ -11,8 +12,10 @@ export const documentSymbols = (environment: Environment) => (params: DocumentSy
     return []
   }
   const document = packageFromURI(params.textDocument.uri, environment)
-  if (!document)
-    throw new Error('Could not produce symbols: document not found')
+  if (!document){
+    logger.error('Could not produce symbols: document not found')
+    return []
+  }
   return documentSymbolsFor(document)
 }
 

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -125,7 +125,7 @@ export const codeLenses = (environment: Environment) => (params: CodeLensParams)
   }
 }
 
-const generateErrorForFile = (connection: Connection, textDocument: TextDocument) => {
+export const generateErrorForFile = (connection: Connection, textDocument: TextDocument): void => {
   const documentUri = wollokURI(textDocument.uri)
   const content = textDocument.getText()
 

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -74,8 +74,6 @@ export const validateTextDocument =
       const problems = validate(environment)
       sendDiagnostics(connection, problems, allDocuments)
       timeMeasurer.addTime(`Validating ${documentUri}`)
-
-      sendDiagnostics(connection, problems, allDocuments)
       timeMeasurer.finalReport()
     } catch (e) {
       generateErrorForFile(connection, textDocument)

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,6 +1,4 @@
 import {
-  CodeLens,
-  CodeLensParams,
   CompletionItem,
   CompletionParams,
   Connection,
@@ -12,20 +10,14 @@ import { Environment, Import, Problem, validate } from 'wollok-ts'
 import { List } from 'wollok-ts/dist/extensions'
 import { completionsForNode } from './functionalities/autocomplete/node-completion'
 import { completeMessages } from './functionalities/autocomplete/send-completion'
-import {
-  getProgramCodeLenses,
-  getTestCodeLenses,
-} from './functionalities/code-lens'
 import { reportValidationMessage } from './functionalities/reporter'
 import { updateDocumentSettings } from './settings'
 import { TimeMeasurer } from './time-measurer'
 import {
-  getWollokFileExtension,
-  packageFromURI,
+  cursorNode,
   trimIn,
 } from './utils/text-documents'
 import { isNodeURI, relativeFilePath, wollokURI } from './utils/vm/wollok'
-import { cursorNode } from './utils/text-documents'
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // INTERNAL FUNCTIONS
@@ -108,21 +100,6 @@ export const completions = (environment: Environment) => (
   const result = autocompleteMessages ? completeMessages(environment, selectionNode) : completionsForNode(selectionNode)
   timeMeasurer.finalReport()
   return result
-}
-
-export const codeLenses = (environment: Environment) => (params: CodeLensParams): CodeLens[] | null => {
-  const fileExtension = getWollokFileExtension(params.textDocument.uri)
-  const file = packageFromURI(params.textDocument.uri, environment)
-  if (!file) return null
-
-  switch (fileExtension) {
-    case 'wpgm':
-      return getProgramCodeLenses(file)
-    case 'wtest':
-      return getTestCodeLenses(file)
-    default:
-      return null
-  }
 }
 
 export const generateErrorForFile = (connection: Connection, textDocument: TextDocument): void => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,7 +20,6 @@ import { typeDescriptionOnHover } from './functionalities/hover'
 import { requestIsRenamable as isRenamable, rename } from './functionalities/rename'
 import { documentSymbols, workspaceSymbols } from './functionalities/symbols'
 import {
-  codeLenses,
   completions,
   validateTextDocument,
 } from './linter'
@@ -28,6 +27,7 @@ import { initializeSettings, WollokLSPSettings } from './settings'
 import { ProgressReporter } from './utils/progress-reporter'
 import { EnvironmentProvider } from './utils/vm/environment'
 import { logger } from './utils/logger'
+import { codeLenses } from './functionalities/code-lens'
 
 export type ClientConfigurations = {
   formatter: { abbreviateAssignments: boolean, maxWidth: number }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -59,8 +59,7 @@ function syncHandler<Params, Return, PR>(requestHandler: ServerRequestHandler<Pa
   return (params, cancel, workDoneProgress, resultProgress) => {
     requestProgressReporter.begin()
     try {
-      const result = requestHandler(params, cancel, workDoneProgress, resultProgress)
-      return result
+      return requestHandler(params, cancel, workDoneProgress, resultProgress)
     } catch(e) {
       logger.error('✘ Failed to process request', e)
       return null

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -157,13 +157,7 @@ const rebuildTextDocument = (change: TextDocumentChangeEvent<TextDocument>) => {
 // when the text document first opened or when its content has changed.
 documents.onDidChangeContent(rebuildTextDocument)
 
-documents.onDidOpen((change) => {
-  try {
-    rebuildTextDocument(change)
-  } catch(e) {
-    connection.console.error(`✘ Failed to rebuild document: ${e}`)
-  }
-})
+documents.onDidOpen(rebuildTextDocument)
 
 connection.onRequest((change) => {
   if (change === 'STRONG_FILES_CHANGED') {

--- a/server/src/utils/vm/environment.ts
+++ b/server/src/utils/vm/environment.ts
@@ -4,7 +4,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { Environment, buildEnvironment } from 'wollok-ts'
 import { inferTypes } from 'wollok-ts/dist/typeSystem/constraintBasedTypeSystem'
 import { ProgressReporter } from '../progress-reporter'
-import { wollokURI } from './wollok'
+import { documentToFile, wollokURI } from './wollok'
 import { TimeMeasurer } from '../../time-measurer'
 import { logger } from '../logger'
 import { generateErrorForFile } from '../../linter'
@@ -26,10 +26,7 @@ export class EnvironmentProvider {
   }
 
   private buildEnvironmentFrom(documents: TextDocument[], baseEnvironment?: Environment): Environment {
-    const files: Parameters<typeof buildEnvironment>[0] = documents.map(document => ({
-        name: wollokURI(document.uri),
-        content: document.getText(),
-    }))
+    const files: Parameters<typeof buildEnvironment>[0] = documents.map(documentToFile)
     this.buildProgressReporter.begin()
     const timeMeasurer = new TimeMeasurer()
     try {

--- a/server/src/utils/vm/environment.ts
+++ b/server/src/utils/vm/environment.ts
@@ -34,7 +34,6 @@ export class EnvironmentProvider {
       timeMeasurer.addTime('Building environment')
       inferTypes(environment)
       timeMeasurer.addTime('Inferring types')
-      this.buildProgressReporter.end()
       return environment
     } catch (error) {
       const message = `✘ Failed to build environment: ${error}`

--- a/server/src/utils/vm/environment.ts
+++ b/server/src/utils/vm/environment.ts
@@ -7,48 +7,52 @@ import { ProgressReporter } from '../progress-reporter'
 import { wollokURI } from './wollok'
 import { TimeMeasurer } from '../../time-measurer'
 import { logger } from '../logger'
+import { generateErrorForFile } from '../../linter'
 
 export class EnvironmentProvider {
   readonly $environment = new BehaviorSubject<Environment | null>(null)
   private buildProgressReporter: ProgressReporter
 
-  constructor(connection: Connection) {
+  constructor(private connection: Connection) {
     this.buildProgressReporter = new ProgressReporter(connection, { identifier: 'wollok-build', title: 'Wollok Building...' })
   }
 
   updateEnvironmentWith(document: TextDocument): void {
-    const uri = wollokURI(document.uri)
-    const content = document.getText()
-    const file: { name: string, content: string } = {
-      name: uri,
-      content: content,
-    }
-    this.$environment.next(this.buildEnvironmentFrom([file], this.$environment.getValue() ?? undefined))
+    this.$environment.next(this.buildEnvironmentFrom([document], this.$environment.getValue() ?? undefined))
   }
 
   resetEnvironment(): void {
     return this.$environment.next(this.buildEnvironmentFrom([]))
   }
 
-  private buildEnvironmentFrom(files: Parameters<typeof buildEnvironment>[0], baseEnvironment?: Environment): Environment {
+  private buildEnvironmentFrom(documents: TextDocument[], baseEnvironment?: Environment): Environment {
+    const files: Parameters<typeof buildEnvironment>[0] = documents.map(document => ({
+        name: wollokURI(document.uri),
+        content: document.getText(),
+    }))
+    this.buildProgressReporter.begin()
+    const timeMeasurer = new TimeMeasurer()
     try {
-      this.buildProgressReporter.begin()
-      const timeMeasurer = new TimeMeasurer()
       const environment = buildEnvironment(files, baseEnvironment)
       timeMeasurer.addTime('Building environment')
       inferTypes(environment)
       timeMeasurer.addTime('Inferring types')
       this.buildProgressReporter.end()
-      timeMeasurer.finalReport()
       return environment
     } catch (error) {
       const message = `✘ Failed to build environment: ${error}`
+      documents.forEach(document => {
+        generateErrorForFile(this.connection, document)
+      })
       logger.error({
         level: 'error',
         files: files.map(file => file.name),
         message,
       })
       throw error
+    } finally {
+      this.buildProgressReporter.end()
+      timeMeasurer.finalReport()
     }
   }
 }

--- a/server/src/utils/vm/wollok.ts
+++ b/server/src/utils/vm/wollok.ts
@@ -1,7 +1,8 @@
 import { is } from 'wollok-ts/dist/extensions'
-import { Class, Entity, Environment, Import, LiteralValue, Method, Module, Node, Package, Reference } from 'wollok-ts'
+import { Class, Entity, Environment, FileContent, Import, LiteralValue, Method, Module, Node, Package, Reference } from 'wollok-ts'
 import fs from 'fs'
 import path from 'path'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 export const OBJECT_CLASS = 'wollok.lang.Object'
 
@@ -50,6 +51,11 @@ export const fqnRelativeToPackage =
     node.fullyQualifiedName.replace(pckg.fullyQualifiedName, pckg.name)
 
 export const wollokURI = (uri: string): string => uri.replace('file:///', '')
+
+export const documentToFile = (doc: TextDocument): FileContent => ({
+  name: wollokURI(doc.uri),
+  content: doc.getText(),
+})
 
 export const isNodeURI = (node: Node, uri: string): boolean => node.sourceFileName == wollokURI(uri)
 


### PR DESCRIPTION
Fix #135 

# Cual era el bug
En un proyecto con dos archivos A (con problemas de parseo) y B (sin problemas) al abrir el proyecto se intentan buildear A que falla pero luego se buildea B y se genera une environment con la forma

```
members
 |- wollok
 |- src
 |--- B
```

Si se quieren generar los simbolos de A la resquest llega (porque existe el environment) pero falla porque el package no existe

# Que hay en el PR

1. El error que esta lanzando para mi es correcto, pero le cambié el throw por un log asi VSCode no repite la request
2. Ahora cuando falla el buildeo del environment se crea el diagnostic en el archivo para indicar que esta sin validar
   - Lo malo de esto es que solo se muestra cuando se abre el archivo o se cambia el contenido 😢. Cree un issue #138 para resolverlo en otro momento
4. Para evitar mas errores de estos le puse un try-catch a todas las requests