### PR TITLE
Fix wollok ts 198 empty if

### DIFF
--- a/server/src/functionalities/hover.ts
+++ b/server/src/functionalities/hover.ts
@@ -8,6 +8,8 @@ type TypeDescriptionResponse = Hover | null
 export const typeDescriptionOnHover = (environment: Environment) => (params: HoverParams): TypeDescriptionResponse => {
   try {
     let node = cursorNode(environment, params.position, params.textDocument)
+    if (!node) return null
+
     if(node.is(Body)){
       node = node.parent
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -151,6 +151,7 @@ const rebuildTextDocument = (change: TextDocumentChangeEvent<TextDocument>) => {
     )
   } catch (e) {
     connection.console.error(`✘ Failed to rebuild document: ${e}`)
+    logger.error(`✘ Failed to rebuild document`, e)
   }
 }
 // The content of a text document has changed. This event is emitted


### PR DESCRIPTION
Para resolver uqbar-project/wollok-ts#198 

- consideramos que en el hover podemos tener un nodo undefined o nulo
- además agregamos el logger para tener el stack trace completo del error (algo que con la RemoteConsole no podemos conseguir)

