### PR TITLE
Mejoras autocomplete en Body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "wollok-lsp-ide",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-lsp-ide",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "dependencies": {
-        "wollok-ts": "4.1.0"
+        "wollok-ts": "4.1.1"
       },
       "devDependencies": {
         "@types/expect": "^24.3.0",
@@ -5857,9 +5857,9 @@
       "dev": true
     },
     "node_modules/wollok-ts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.1.0.tgz",
-      "integrity": "sha512-qAdBR7nHIK6daPW8a3v42+Ii0lHaMd1jxasUUwAPSSYysEoPBnT+0ruH6yK4Byjv2Rn4b4t0ppnkIC9/UOdkyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.1.1.tgz",
+      "integrity": "sha512-pALSw4ojwhn2yjOcf6pPr1ujGjUOigD6saSLLl0EWAjcIO3rwhaxqSkpGs/P3CtJk8F8zu8LRtpgNX2K+7mTBQ==",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",
         "parsimmon": "^1.18.1",
@@ -10144,9 +10144,9 @@
       "dev": true
     },
     "wollok-ts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.1.0.tgz",
-      "integrity": "sha512-qAdBR7nHIK6daPW8a3v42+Ii0lHaMd1jxasUUwAPSSYysEoPBnT+0ruH6yK4Byjv2Rn4b4t0ppnkIC9/UOdkyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.1.1.tgz",
+      "integrity": "sha512-pALSw4ojwhn2yjOcf6pPr1ujGjUOigD6saSLLl0EWAjcIO3rwhaxqSkpGs/P3CtJk8F8zu8LRtpgNX2K+7mTBQ==",
       "requires": {
         "@types/parsimmon": "^1.10.8",
         "parsimmon": "^1.18.1",

--- a/server/src/functionalities/autocomplete/autocomplete.ts
+++ b/server/src/functionalities/autocomplete/autocomplete.ts
@@ -35,11 +35,11 @@ export const completions = (environment: Environment) => (
 // -----------------
 type CompletionItemMapper<T extends Node> = (node: T) => CompletionItem
 
-export const parameterCompletionItem: CompletionItemMapper<Parameter> = namedCompletionItem(CompletionItemKind.Variable, '002')
+export const parameterCompletionItem: CompletionItemMapper<Parameter> = namedCompletionItem(CompletionItemKind.Variable, '006')
 
-export const variableCompletionItem: CompletionItemMapper<Variable> = namedCompletionItem(CompletionItemKind.Variable, '001')
+export const variableCompletionItem: CompletionItemMapper<Variable> = namedCompletionItem(CompletionItemKind.Variable, '003')
 
-export const fieldCompletionItem: CompletionItemMapper<Field> = namedCompletionItem(CompletionItemKind.Field, '003')
+export const fieldCompletionItem: CompletionItemMapper<Field> = namedCompletionItem(CompletionItemKind.Field, '009')
 
 export const singletonCompletionItem: CompletionItemMapper<Singleton> = moduleCompletionItem(CompletionItemKind.Class)
 
@@ -115,7 +115,7 @@ export const methodCompletionItem = (node: Node, method: Method): CompletionItem
 
 
 function moduleCompletionItem<T extends Module>(kind: CompletionItemKind){
-  return (module: T) => namedCompletionItem(kind, '004')(module.name ? module as {name: Name} : { name: 'unnamed' })
+  return (module: T) => namedCompletionItem(kind, '012')(module.name ? module as {name: Name} : { name: 'unnamed' })
 }
 
 function namedCompletionItem<T extends {name: string}>(kind: CompletionItemKind, sortText = '999') {

--- a/server/src/functionalities/references.ts
+++ b/server/src/functionalities/references.ts
@@ -1,10 +1,14 @@
 import { Location, ReferenceParams } from 'vscode-languageserver'
 import { Environment, Method, mayExecute, targettingAt } from 'wollok-ts'
 import { cursorNode, nodeToLocation } from '../utils/text-documents'
+import { logger } from '../utils/logger'
 
 export const references = (environment: Environment) => (params: ReferenceParams): Location[] | null => {
   const node = cursorNode(environment, params.position, params.textDocument)
-  if (!node) throw new Error('Could not find selection node')
+  if (!node) {
+    logger.error('✘ Could not find the node to search references for')
+    return null
+  }
   return environment.descendants.filter(
     node.is(Method) ?
       mayExecute(node) :

--- a/server/src/functionalities/references.ts
+++ b/server/src/functionalities/references.ts
@@ -4,7 +4,7 @@ import { cursorNode, nodeToLocation } from '../utils/text-documents'
 
 export const references = (environment: Environment) => (params: ReferenceParams): Location[] | null => {
   const node = cursorNode(environment, params.position, params.textDocument)
-
+  if (!node) throw new Error('Could not find selection node')
   return environment.descendants.filter(
     node.is(Method) ?
       mayExecute(node) :

--- a/server/src/test/mocks/file-contents.ts
+++ b/server/src/test/mocks/file-contents.ts
@@ -3,6 +3,7 @@ export const pepitaFile = `object pepita {
   var peso = 0
 
   method comer(comida){
-    peso = peso + comida.calorias()
+    var gramos = comida.calorias()
+    peso = peso + gramos
   }
 }`

--- a/server/src/utils/text-documents.ts
+++ b/server/src/utils/text-documents.ts
@@ -103,7 +103,7 @@ export function cursorNode(
   environment: Environment,
   position: Position,
   textDocument: TextDocumentIdentifier
-): Node {
+): Node | undefined {
   return getNodesByPosition(environment, {
     position,
     textDocument,


### PR DESCRIPTION
fix #155 

- [x] Los bodies (test/singleton) ahora autocompletan las variables de su scope 
- [x] Los tests ahora tambien autocompletan los fields del describe y los wko del proyecto
- [x] Ordenar completions para tests/methods (variables -> parametros -> atributos -> modulos -> snippets)
- [ ] Cuando el cursor estan en medio de una sentencia malformada `assert.equals(` analizar el contexto
    - Esto me parece que merece un issue a parte, por ahora con las opciones que ofrece el body me conformo 