### PR TITLE
Test command: filename as string instead of package name

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -49,7 +49,7 @@ export const runTest = ([filter, file, describe, test]: [string|null, string|nul
   wollokCLITask('run tests', 'Wollok run test', [
     'test',
     ...filter ? [`${asShellString(filter)}`] : [],
-    ...file ? ['-f', file] : [],
+    ...file ? ['-f', asShellString(file)] : [],
     ...describe ? ['-d', `${asShellString(describe)}`] : [],
     ...test ? ['-t', `${asShellString(test)}`] : [],
     '--skipValidations',

--- a/client/src/test/code-lens.test.ts
+++ b/client/src/test/code-lens.test.ts
@@ -33,7 +33,7 @@ suite('Should do code lenses', () => {
         {
           title: 'Run all tests',
           command: 'wollok.run.test',
-          arguments: [null, 'test', null, null],
+          arguments: [null, 'test.wtest', null, null],
         },
       ),
       new CodeLens(
@@ -41,7 +41,7 @@ suite('Should do code lenses', () => {
         {
           title: 'Run describe',
           command: 'wollok.run.test',
-          arguments: [null, 'test', 'pepita test', null],
+          arguments: [null, 'test.wtest', 'pepita test', null],
         },
       ),
       new CodeLens(
@@ -49,7 +49,7 @@ suite('Should do code lenses', () => {
         {
           title: 'Run test',
           command: 'wollok.run.test',
-          arguments: [null, 'test', 'pepita test', 'pepita is happy'],
+          arguments: [null, 'test.wtest', 'pepita test', 'pepita is happy'],
         },
       ),
     ])

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -48,9 +48,9 @@ suite('Should run commands', () => {
 
   suite('run tests', () => {
     const SEP = '<SEP>'
-    const testCommandOptions = `-f tests -d ${SEP}tests de pepita${SEP} -t ${SEP}something${SEP}`
+    const testCommandOptions = `-f ${SEP}tests.wtest${SEP} -d ${SEP}tests de pepita${SEP} -t ${SEP}something${SEP}`
 
-    const testArgs: [string, string, string, string] = [null, 'tests', 'tests de pepita', 'something']
+    const testArgs: [string, string, string, string] = [null, 'tests.wtest', 'tests de pepita', 'something']
 
     async function runCommandOnPlatform(
       platform: string,

--- a/server/src/functionalities/code-lens.ts
+++ b/server/src/functionalities/code-lens.ts
@@ -56,12 +56,12 @@ const isTesteable = (node: Node): node is Test | Describe =>
 const isWollokDefinition = (node: Node): node is Class | Singleton =>
   node.is(Class) || node.is(Singleton)
 
-  const buildRunAllTestsCodeLens = (file: Package): CodeLens =>
+const buildRunAllTestsCodeLens = (file: Package): CodeLens =>
   buildTestsCodeLens(
     Range.create(Position.create(0, 0), Position.create(0, 0)),
     'wollok.run.test',
     'Run all tests',
-    [null, file.name, null, null]
+    [null, file.fileName!, null, null]
   )
 
 
@@ -75,7 +75,7 @@ const buildTestCodeLens = (file: Package, node: Test | Describe): CodeLens => {
     `Run ${node.is(Test) ? 'test' : 'describe'}`,
     [
       null,
-      file.name,
+      file.fileName!,
       describe ? removeQuotes(describe) : null,
       test ? removeQuotes(test) : null,
     ]


### PR DESCRIPTION
### ⚠️  Depende de https://github.com/uqbar-project/wollok-ts-cli/pull/162

Fix #168 

En un proyecto

```
.
├── package.json
└── src/
    ├── pepita.wlk
    └── pepita.wtest
```


Si queria correr los tests de `pepita.wtest` podia fallar si wollok-cli matcheaba primero con `pepita.wlk` para correr los tests. Ahora se envia el path entero


Comando generado cambia de

```bash
wollok  test -f pepita --skipValidations -p /path/to/project
```
a
```bash
wollok  test -f 'src/pepita.wtest'  --skipValidations -p /path/to/project
```



