### PR TITLE
Fix #176 - add quotes to command

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -12,7 +12,6 @@ import {
 import {
   asShellString,
   fsToShell,
-  unknownToShell,
 } from './platform-string-utils'
 import { COMMAND_RUN_ALL_TESTS, COMMAND_RUN_GAME, COMMAND_RUN_PROGRAM, COMMAND_RUN_TEST, COMMAND_START_REPL, wollokLSPExtensionCode } from './shared-definitions'
 
@@ -34,13 +33,13 @@ export const subscribeWollokCommands = (context: ExtensionContext): void => {
  * CLI Commands
  */
 
-export const runProgram = (isGame = false) => (fqn: string): Task => {
+export const runProgram = (isGame = false) => ([fqn]: [string]): Task => {
   // Terminate previous terminal session
   vscode.commands.executeCommand('workbench.action.terminal.killAll')
   return wollokCLITask('run program', `Wollok run ${isGame ? 'game' : 'program'}`, [
     'run',
     ...isGame ? ['-g'] : [],
-    `'${fqn}'`,
+    asShellString(fqn),
     '--skipValidations',
   ])
 }
@@ -48,10 +47,10 @@ export const runProgram = (isGame = false) => (fqn: string): Task => {
 export const runTest = ([filter, file, describe, test]: [string|null, string|null, string|null, string|null]): Task =>
   wollokCLITask('run tests', 'Wollok run test', [
     'test',
-    ...filter ? [`${asShellString(filter)}`] : [],
+    ...filter ? [asShellString(filter)] : [],
     ...file ? ['-f', asShellString(file)] : [],
-    ...describe ? ['-d', `${asShellString(describe)}`] : [],
-    ...test ? ['-t', `${asShellString(test)}`] : [],
+    ...describe ? ['-d', asShellString(describe)] : [],
+    ...test ? ['-t', asShellString(test)] : [],
     '--skipValidations',
   ])
 
@@ -64,7 +63,7 @@ export const runAllTests = (): Task =>
 const getCurrentFileName = (document: vscode.TextDocument | undefined) =>
   document ? path.basename(document.uri.path) : 'Synthetic File'
 
-const getFiles = (document: vscode.TextDocument | undefined) =>
+const getFiles = (document: vscode.TextDocument | undefined): [ReturnType<typeof fsToShell>] | []  =>
   document ? [fsToShell(document.uri.fsPath)] : []
 
 const DYNAMIC_DIAGRAM_URI = 'http://localhost:3000/'
@@ -106,28 +105,26 @@ const registerCLICommand = (
     tasks.executeTask(taskBuilder(args)),
   )
 
-const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
-  const wollokCliPath: string = fsToShell(workspace.getConfiguration(wollokLSPExtensionCode).get('cli-path'))
+const wollokCLITask = (task: string, name: string, cliCommands: Array<string | vscode.ShellQuotedString>) => {
+  const wollokCliPath: string = workspace.getConfiguration(wollokLSPExtensionCode).get('cli-path')
   // TODO: i18n - but it's in the server
   if (!wollokCliPath) {
     vscode.commands.executeCommand('workbench.action.openSettings', wollokLSPExtensionCode)
     throw new Error('Missing configuration WollokLSP/cli-path. Set the path where wollok-ts-cli is located in order to run Wollok tasks')
   }
 
-  const wollokCli = unknownToShell(wollokCliPath)
   const folder = workspace.workspaceFolders[0]
-  const shellCommand = [
-    wollokCli,
+  const shellCommandArgs: Array<string | vscode.ShellQuotedString> = [
     ...cliCommands,
     '-p',
     fsToShell(folder.uri.fsPath),
-  ].join(' ')
+  ]
 
   return new Task(
     { type: 'wollok', task },
     folder,
     name,
     'wollok',
-    new ShellExecution(shellCommand),
+    new ShellExecution(fsToShell(wollokCliPath), shellCommandArgs),
   )
 }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -107,7 +107,7 @@ const registerCLICommand = (
   )
 
 const wollokCLITask = (task: string, name: string, cliCommands: string[]) => {
-  const wollokCliPath: string = workspace.getConfiguration(wollokLSPExtensionCode).get('cli-path')
+  const wollokCliPath: string = fsToShell(workspace.getConfiguration(wollokLSPExtensionCode).get('cli-path'))
   // TODO: i18n - but it's in the server
   if (!wollokCliPath) {
     vscode.commands.executeCommand('workbench.action.openSettings', wollokLSPExtensionCode)

--- a/client/src/platform-string-utils.ts
+++ b/client/src/platform-string-utils.ts
@@ -29,7 +29,8 @@ export function resolvePathParser(): path.PlatformPath {
 }
 
 export function fsToShell(fsPath: string): string {
-  return transformSeparators(fsPath, path.sep, resolvePathParser().sep)
+  const quotes = fsPath.includes('"') ? '\'' : '"'
+  return quotes + transformSeparators(fsPath, path.sep, resolvePathParser().sep) + quotes
 }
 
 export function unknownToShell(aPath: string): string {

--- a/client/src/platform-string-utils.ts
+++ b/client/src/platform-string-utils.ts
@@ -1,50 +1,12 @@
 import path = require('path')
-import { replaceAll } from './utils'
-import { env } from 'vscode'
+import { ShellQuotedString, ShellQuoting, env } from 'vscode'
 
-export type Shell = 'bash' | 'cmd' | 'pwsh' | 'zsh'
-
-export function asShellString(string: string): string {
-  if (activeShell() === 'cmd') {
-    return `"${replaceAll(string, '"', '')}"`
-  }
-  return `'${string}'`
+export function asShellString(string: string): ShellQuotedString {
+  return { quoting: ShellQuoting.Strong, value: string }
 }
 
-export function asShellPath(abstractPath: string[]): string {
-  const pathParser = resolvePathParser()
-  return pathParser.resolve(...abstractPath)
-}
-
-function shellPathEncoding(): 'win32' | 'posix' {
-  if (process.platform === 'win32') {
-    return activeShell() === 'bash' ? 'posix' : 'win32'
-  } else {
-    return 'posix'
-  }
-}
-
-export function resolvePathParser(): path.PlatformPath {
-  return shellPathEncoding() === 'win32' ? path.win32 : path.posix
-}
-
-export const getQuotesFor = (path: string): string => path.includes('"') ? '\'' : '"'
-
-export function fsToShell(fsPath: string): string {
-  const quotes = getQuotesFor(fsPath)
-  return quotes + transformSeparators(fsPath, path.sep, resolvePathParser().sep) + quotes
-}
-
-export function unknownToShell(aPath: string): string {
-  return (shellPathEncoding() === 'posix' ? toPosix : toWin)(aPath)
-}
-
-export function toPosix(path: string): string {
-  return transformSeparators(path, '\\', '/')
-}
-
-export function toWin(path: string): string {
-  return transformSeparators(path, '/', '\\')
+export function fsToShell(fsPath: string): ShellQuotedString {
+  return asShellString(fsPath)
 }
 
 export function transformSeparators(
@@ -53,14 +15,4 @@ export function transformSeparators(
   targetSep: string,
 ): string {
   return path.split(originalSep).join(targetSep)
-}
-
-/**
- * @param shellPath
- * @returns Matching shell identifier
- * @default 'bash'
- */
-function activeShell(): Shell {
-  const shells = ['cmd', 'pwsh', 'bash', 'zsh'] as const
-  return shells.find((shell) => env.shell.includes(shell)) || 'bash'
 }

--- a/client/src/platform-string-utils.ts
+++ b/client/src/platform-string-utils.ts
@@ -28,8 +28,10 @@ export function resolvePathParser(): path.PlatformPath {
   return shellPathEncoding() === 'win32' ? path.win32 : path.posix
 }
 
+export const getQuotesFor = (path: string): string => path.includes('"') ? '\'' : '"'
+
 export function fsToShell(fsPath: string): string {
-  const quotes = fsPath.includes('"') ? '\'' : '"'
+  const quotes = getQuotesFor(fsPath)
   return quotes + transformSeparators(fsPath, path.sep, resolvePathParser().sep) + quotes
 }
 

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -26,10 +26,10 @@ suite('Should run commands', () => {
       () => runProgram()(['file.program']),
       [
         'run',
-        { quoting: ShellQuoting.Strong, value: 'file.program' },
+        quoted('file.program'),
         '--skipValidations',
         '-p',
-        { quoting: ShellQuoting.Strong, value: folderURI.fsPath }
+        quoted(folderURI.fsPath),
       ],
     )
   })
@@ -41,10 +41,10 @@ suite('Should run commands', () => {
       [ 
         'run', 
         '-g', 
-        { quoting: ShellQuoting.Strong, value: 'file.program' },
+        quoted('file.program'),
         '--skipValidations',
         '-p',
-        { quoting: ShellQuoting.Strong, value: folderURI.fsPath }
+        quoted(folderURI.fsPath),
       ],
     )
   })
@@ -59,14 +59,14 @@ suite('Should run commands', () => {
       [
         'test', 
         '-f',
-        { quoting: ShellQuoting.Strong, value: 'tests.wtest' },
+        quoted('tests.wtest'),
         '-d',
-        { quoting: ShellQuoting.Strong, value: 'tests de pepita' },
+        quoted('tests de pepita'),
         '-t',
-        { quoting: ShellQuoting.Strong, value: 'something' },
+        quoted('something'),
         '--skipValidations',
         '-p',
-        { quoting: ShellQuoting.Strong, value:folderURI.fsPath }
+        { quoting: ShellQuoting.Strong, value:folderURI.fsPath },
       ],
     )
   })
@@ -79,7 +79,7 @@ suite('Should run commands', () => {
         'test', 
         '--skipValidations',
         '-p',
-        { quoting: ShellQuoting.Strong,value:folderURI.fsPath }
+        quoted(folderURI.fsPath)
       ],
     )
   })
@@ -90,12 +90,12 @@ suite('Should run commands', () => {
         startRepl,
         [
           'repl',
-          { quoting: ShellQuoting.Strong,value:pepitaURI.fsPath },
+          quoted(pepitaURI.fsPath),
           '--skipValidations',
           '--darkMode',
           '', // do not open dynamic diagram
           '-p',
-          { quoting: ShellQuoting.Strong,value:folderURI.fsPath },
+          quoted(folderURI.fsPath),
         ],
       )
   })
@@ -124,4 +124,8 @@ function assertCommandSegmentMatches(actual: string | ShellQuotedString, expecte
     assert.equal(actual.value, (expected as ShellQuotedString).value)
     assert.equal(actual.quoting, (expected as ShellQuotedString).quoting)
   }
+}
+
+function quoted(aString: string): ShellQuotedString {
+  return { quoting: ShellQuoting.Strong, value: aString }
 }

--- a/client/src/test/commands.test.ts
+++ b/client/src/test/commands.test.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon'
 import { ShellExecution, Task, Uri, env, workspace } from 'vscode'
 import { runAllTests, runProgram, runTest, startRepl } from '../commands'
 import { activate, getDocumentURI, getFolderURI } from './helper'
-import { toPosix, toWin, Shell } from '../platform-string-utils'
+import { toPosix, toWin, Shell, getQuotesFor } from '../platform-string-utils'
 import { afterEach, beforeEach } from 'mocha'
 
 suite('Should run commands', () => {
@@ -97,7 +97,7 @@ suite('Should run commands', () => {
       testCommand(
         pepitaURI,
         startRepl,
-        ` repl ${toPosix(
+        ` repl ${expectedPathByShell(env.shell as Shell,
           pepitaURI.fsPath,
         )} --skipValidations --darkMode  -p ${expectedPathByShell(
           'bash',
@@ -120,11 +120,9 @@ async function testCommand(
 }
 
 function expectedPathByShell(cmd: Shell, originalPath: string) {
-  if (['bash', 'zsh'].includes(cmd)) {
-    return toPosix(originalPath)
-  } else {
-    return toWin(originalPath)
-  }
+  const quotes = getQuotesFor(originalPath)
+  const newPath = ['bash', 'zsh'].includes(cmd) ? toPosix(originalPath) : toWin(originalPath)
+  return quotes + newPath + quotes
 }
 
 async function onWindowsBash(test: () => Promise<any>) {

--- a/client/src/test/hover.test.ts
+++ b/client/src/test/hover.test.ts
@@ -43,8 +43,10 @@ suite('Should display on hover', () => {
 async function testHover(uri: Uri, position: Position, expected: any): Promise<void> {
   await activate(uri)
   const actual = await commands.executeCommand('vscode.executeHoverProvider', uri, position)
-  delete actual[0]['canDecreaseHover']
-  delete actual[0]['canIncreaseHover']
+  // delete actual[0]['canDecreaseHover']
+  // delete actual[0]['canIncreaseHover']
+  delete actual[0]['canDecreaseVerbosity']
+  delete actual[0]['canIncreaseVerbosity']
   assert.deepEqual(actual, [expected])
   assert.deepEqual(
     actual[0].contents.map(content => content.value),

--- a/client/src/test/hover.test.ts
+++ b/client/src/test/hover.test.ts
@@ -43,8 +43,6 @@ suite('Should display on hover', () => {
 async function testHover(uri: Uri, position: Position, expected: any): Promise<void> {
   await activate(uri)
   const actual = await commands.executeCommand('vscode.executeHoverProvider', uri, position)
-  // delete actual[0]['canDecreaseHover']
-  // delete actual[0]['canIncreaseHover']
   delete actual[0]['canDecreaseVerbosity']
   delete actual[0]['canIncreaseVerbosity']
   assert.deepEqual(actual, [expected])


### PR DESCRIPTION
Arregla #176 

Le agregué las comillas y probé con esta carpeta en Linux Mint que originalmente me daba error: `de es& "mo!`

![image](https://github.com/user-attachments/assets/c42bc62f-d466-4739-8565-923e2d30ebb3)

![image](https://github.com/user-attachments/assets/e26a64a3-2ab9-4106-bb76-e849cbbca241)

Algunas cosas

- voy a ver si lo pruebo en Windows
- si a una persona se le ocurre poner comillas simples y dobles, algo como `soy"muy 'original` no hay forma de que funcione
- por defecto usamos comillas dobles, salvo que en la carpeta haya comillas dobles, ahí usamos comillas simples

