### PR TITLE
i18n - parte 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
       },
       {
         "command": "wollok.init.project",
-        "title": "Initialize new Wollok project in the workspace directory",
+        "title": "Generate a new Wollok project in current folder",
         "category": "Wollok"
       }
     ],

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -44,7 +44,7 @@ export const runProgram = (isGame = false) => ([fqn]: [string]): Task => {
 
   // Terminate previous terminal session
   vscode.commands.executeCommand('workbench.action.terminal.killAll')
-  return wollokCLITask('run program', `Wollok run ${isGame ? 'game' : 'program'}`, [
+  return wollokCLITask('run program', `Wollok ${getLSPMessage(isGame ? COMMAND_RUN_GAME : COMMAND_RUN_PROGRAM)}`, [
     'run',
     ...isGame ? ['-g', '--port', portNumber.toString()] : [],
     asShellString(fqn),
@@ -53,7 +53,7 @@ export const runProgram = (isGame = false) => ([fqn]: [string]): Task => {
 }
 
 export const runTest = ([filter, file, describe, test]: [string|null, string|null, string|null, string|null]): Task =>
-  wollokCLITask('run tests', 'Wollok run test', [
+  wollokCLITask('run tests', `Wollok ${getLSPMessage(COMMAND_RUN_TEST)}`, [
     'test',
     ...filter ? [asShellString(filter)] : [],
     ...file ? ['-f', asShellString(file)] : [],
@@ -63,7 +63,7 @@ export const runTest = ([filter, file, describe, test]: [string|null, string|nul
   ])
 
 export const runAllTests = (): Task =>
-  wollokCLITask('run tests', 'Wollok run all tests', [
+  wollokCLITask('run tests', `Wollok ${getLSPMessage(COMMAND_RUN_ALL_TESTS)}`, [
     'test',
     '--skipValidations',
   ])

--- a/packages/client/src/messages.ts
+++ b/packages/client/src/messages.ts
@@ -1,5 +1,5 @@
 import { getMessage, LANGUAGES, Messages } from 'wollok-ts'
-import { wollokLSPExtensionCode } from './shared-definitions'
+import { COMMAND_RUN_ALL_TESTS, COMMAND_RUN_GAME, COMMAND_RUN_PROGRAM, COMMAND_RUN_TEST, wollokLSPExtensionCode } from './shared-definitions'
 import { workspace } from 'vscode'
 
 export const languageDescription: { [key: string]: LANGUAGES } = {
@@ -13,10 +13,18 @@ export const lspClientMessages: Messages = {
   [LANGUAGES.ENGLISH]: {
     missingWollokCliPath: 'Missing configuration WollokLSP/cli-path. Set the path where wollok-ts-cli is located in order to run Wollok tasks',
     wollokBuilding: 'Wollok Building...',
+    [COMMAND_RUN_GAME]: 'run game',
+    [COMMAND_RUN_PROGRAM]: 'run program',
+    [COMMAND_RUN_ALL_TESTS]: 'run all tests',
+    [COMMAND_RUN_TEST]: 'run test',
   },
   [LANGUAGES.SPANISH]: {
     missingWollokCliPath: 'Falta configurar la ruta donde está instalado wollok-ts-cli. Este paso es necesario para ejecutar cualquier comando de Wollok.',
     wollokBuilding: 'Generando Wollok...',
+    [COMMAND_RUN_GAME]: 'ejecutar juego',
+    [COMMAND_RUN_PROGRAM]: 'ejecutar programa',
+    [COMMAND_RUN_ALL_TESTS]: 'ejecutar todos los tests',
+    [COMMAND_RUN_TEST]: 'ejecutar test',
   },
 }
 

--- a/packages/server/src/functionalities/code-lens.ts
+++ b/packages/server/src/functionalities/code-lens.ts
@@ -2,7 +2,8 @@ import { CodeLens, CodeLensParams, Position, Range } from 'vscode-languageserver
 import { Describe, Node, Package, Test, Program, Environment, is, PROGRAM_FILE_EXTENSION, TEST_FILE_EXTENSION, WOLLOK_FILE_EXTENSION, Class, Singleton, Entity } from 'wollok-ts'
 import { getWollokFileExtension, packageFromURI, toVSCRange } from '../utils/text-documents'
 import { removeQuotes } from '../utils/strings'
-import { COMMAND_RUN_GAME, COMMAND_RUN_PROGRAM, COMMAND_RUN_TEST, COMMAND_START_REPL } from '../shared-definitions'
+import { COMMAND_RUN_ALL_TESTS, COMMAND_RUN_GAME, COMMAND_RUN_PROGRAM, COMMAND_RUN_TEST, COMMAND_START_REPL } from '../shared-definitions'
+import { COMMAND_EXECUTE, getLSPMessage } from './reporter'
 
 export const codeLenses = (environment: Environment) => (params: CodeLensParams): CodeLens[] | null => {
   const fileExtension = getWollokFileExtension(params.textDocument.uri)
@@ -23,8 +24,8 @@ export const codeLenses = (environment: Environment) => (params: CodeLensParams)
 
 export const getProgramCodeLenses = (file: Package): CodeLens[] =>
   file.members.filter(is(Program)).flatMap(program => [
-    buildLens(program, COMMAND_RUN_GAME, 'Run game'),
-    buildLens(program, COMMAND_RUN_PROGRAM, 'Run program'),
+    buildLens(program, COMMAND_RUN_GAME, getLSPMessage(COMMAND_RUN_GAME)),
+    buildLens(program, COMMAND_RUN_PROGRAM, getLSPMessage(COMMAND_RUN_PROGRAM)),
   ])
 
 
@@ -43,7 +44,7 @@ export const getTestCodeLenses = (file: Package): CodeLens[] => {
 
 export const getWollokFileCodeLenses = (file: Package): CodeLens[] =>
   file.members.filter(isWollokDefinition).map(definition =>
-    buildLens(definition, COMMAND_START_REPL, 'Run in REPL'),
+    buildLens(definition, COMMAND_START_REPL, getLSPMessage(COMMAND_START_REPL)),
   )
 
 /************************************************************************************************/
@@ -60,7 +61,7 @@ const buildRunAllTestsCodeLens = (file: Package): CodeLens =>
   buildTestsCodeLens(
     Range.create(Position.create(0, 0), Position.create(0, 0)),
     'wollok.run.test',
-    'Run all tests',
+    getLSPMessage(COMMAND_RUN_ALL_TESTS),
     [null, file.fileName!, null, null]
   )
 
@@ -72,7 +73,7 @@ const buildTestCodeLens = (file: Package, node: Test | Describe): CodeLens => {
   return buildTestsCodeLens(
     toVSCRange(node.sourceMap!),
     COMMAND_RUN_TEST,
-    `Run ${node.is(Test) ? 'test' : 'describe'}`,
+    getLSPMessage(COMMAND_EXECUTE, [`${node.is(Test) ? 'test' : 'describe'}`]),
     [
       null,
       file.fileName!,

--- a/packages/server/src/functionalities/reporter.ts
+++ b/packages/server/src/functionalities/reporter.ts
@@ -1,18 +1,35 @@
 import { getMessage, LANGUAGES, Messages, Problem } from 'wollok-ts'
 import { lang } from '../settings'
+import { COMMAND_RUN_ALL_TESTS, COMMAND_RUN_GAME, COMMAND_RUN_PROGRAM, COMMAND_RUN_TEST, COMMAND_START_REPL } from '../shared-definitions'
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // CUSTOM MESSAGES DEFINITION
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
-const MISSING_WOLLOK_TS_CLI = 'missing_wollok_ts_cli'
+export const COMMAND_EXECUTE = 'command.execute'
+export const SERVER_PROCESSING_REQUEST = 'server_processing_request'
+export const ERROR_MISSING_WORKSPACE_FOLDER = 'missing_workspace_folder'
 
 const lspMessagesEn = {
-  [MISSING_WOLLOK_TS_CLI]: 'Missing configuration WollokLSP/cli-path in order to run Wollok tasks',
+  [COMMAND_RUN_GAME]: 'Run Game',
+  [COMMAND_RUN_PROGRAM]: 'Run Program',
+  [COMMAND_START_REPL]: 'Run in REPL',
+  [COMMAND_RUN_ALL_TESTS]: 'Run all tests',
+  [COMMAND_RUN_TEST]: 'Run test',
+  [COMMAND_EXECUTE]: 'Run {0}',
+  [SERVER_PROCESSING_REQUEST]: 'Processing Request...',
+  [ERROR_MISSING_WORKSPACE_FOLDER]: 'Missing workspace folder!',
 }
 
 const lspMessagesEs = {
-  [MISSING_WOLLOK_TS_CLI]: 'Falta la configuración WollokLSP/cli-path para poder ejecutar tareas de Wollok',
+  [COMMAND_RUN_GAME]: 'Jugar',
+  [COMMAND_RUN_PROGRAM]: 'Ejecutar programa',
+  [COMMAND_START_REPL]: 'Ejecutar REPL',
+  [COMMAND_RUN_ALL_TESTS]: 'Ejecutar todos los tests',
+  [COMMAND_RUN_TEST]: 'Ejecutar test',
+  [COMMAND_EXECUTE]: 'Ejecutar {0}',
+  [SERVER_PROCESSING_REQUEST]: 'Procesando...',
+  [ERROR_MISSING_WORKSPACE_FOLDER]: '¡No existe la carpeta de trabajo principal!',
 }
 
 const lspMessages: Messages = {
@@ -31,5 +48,5 @@ const lspMessages: Messages = {
 export const reportValidationMessage = (problem: Problem): string =>
   getMessage({ message: problem.code, values: problem.values.concat(), language: lang() })
 
-export const getLSPMessage = (message: string, values: string[]): string =>
+export const getLSPMessage = (message: string, values: string[] = []): string =>
   getMessage({ message, values, language: lang(), customMessages: lspMessages })

--- a/packages/server/src/functionalities/reporter.ts
+++ b/packages/server/src/functionalities/reporter.ts
@@ -11,8 +11,8 @@ export const SERVER_PROCESSING_REQUEST = 'server_processing_request'
 export const ERROR_MISSING_WORKSPACE_FOLDER = 'missing_workspace_folder'
 
 const lspMessagesEn = {
-  [COMMAND_RUN_GAME]: 'Run Game',
-  [COMMAND_RUN_PROGRAM]: 'Run Program',
+  [COMMAND_RUN_GAME]: 'Run game',
+  [COMMAND_RUN_PROGRAM]: 'Run program',
   [COMMAND_START_REPL]: 'Run in REPL',
   [COMMAND_RUN_ALL_TESTS]: 'Run all tests',
   [COMMAND_RUN_TEST]: 'Run test',

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -30,6 +30,7 @@ import { ProgressReporter } from './utils/progress-reporter'
 import { setWorkspaceUri, WORKSPACE_URI } from './utils/text-documents'
 import { EnvironmentProvider } from './utils/vm/environment'
 import { completions } from './functionalities/autocomplete/autocomplete'
+import { ERROR_MISSING_WORKSPACE_FOLDER, getLSPMessage, SERVER_PROCESSING_REQUEST } from './functionalities/reporter'
 
 export type ClientConfigurations = {
   formatter: { abbreviateAssignments: boolean, maxWidth: number }
@@ -57,7 +58,7 @@ const config = new Subject<ClientConfigurations>()
 config.forEach(config => environmentProvider.inferTypes = config.typeSystem.enabled)
 const requestContext = combineLatest([environmentProvider.$environment.pipe(filter(environment => environment != null)), config])
 
-const requestProgressReporter = new ProgressReporter(connection, { identifier: 'wollok-request', title: 'Processing Request...' })
+const requestProgressReporter = new ProgressReporter(connection, { identifier: 'wollok-request', title: getLSPMessage(SERVER_PROCESSING_REQUEST) })
 
 let hasWorkspaceFolderCapability = false
 
@@ -137,7 +138,7 @@ const rebuildTextDocument = (change: TextDocumentChangeEvent<TextDocument>) => {
   try {
     if (!WORKSPACE_URI) { // Too fast! We cannot yet...
       deferredChanges.push(change) // Will be executed when workspace folder arrive
-      throw new Error('Missing workspace folder!')
+      throw new Error(getLSPMessage(ERROR_MISSING_WORKSPACE_FOLDER))
     }
 
     environmentProvider.updateEnvironmentWith(change.document)


### PR DESCRIPTION
Ahora que tenemos la función que puede internacionalizar mensajes en wollok-ts, completé los mensajes que muestra el IDE para

- code lenses
- mensajes de error que llegan a la UI

![image](https://github.com/user-attachments/assets/83aa7528-5892-4802-9e8c-80df8d807dd9)

![image](https://github.com/user-attachments/assets/5d12b2b8-ecc6-4e81-a45a-d7f12721d2ad)

![image](https://github.com/user-attachments/assets/b616ec66-d62c-4a7d-9873-58a9df1ce696)

### Que no (y está bien)

Decidí que el logger de eventos siga manteniéndose en inglés porque es más para nosotros:

![image](https://github.com/user-attachments/assets/ebd135ea-82ff-4b3d-9160-e15332f903b9)

### Que no pude

Lamentablemente, hay dos lugares donde no estoy pudiendo customizar los mensajes

- settings
- command (lo que se muestra con F1)

![image](https://github.com/user-attachments/assets/519a49e4-4f57-4718-9d51-990634e45775)

![image](https://github.com/user-attachments/assets/c914e125-d9da-4ffc-b1ae-29bf94b7108a)

porque se definen en el `package.json`. Si bien le puse i18n al `name` de cada task que creamos, el nombre no es lo que aparece en la UI sino el `title`. Busqué [la documentación oficial de Command](https://code.visualstudio.com/api/extension-guides/command) pero lamentablemente no dice nada y [tampoco hay issues cargados](https://github.com/microsoft/language-server-protocol/issues). Voy a abrir un issue a ver qué me responden.

Lo mismo en los settings, las descripciones son las que definimos en el `package.json`.