### PR TITLE
Fix #210

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  precision: 2
+  round: down
+  range: "80...100"
   status:
     project:
       default:


### PR DESCRIPTION
Ya estaba configurado que con menos de 2% de diferencia de cobertura no rompa los PRs. Le agrego que nos mantengamos en un rango de 80% de cobertura o más (hoy tenemos 85%).
