### PR TITLE
Fix CI error on highlighter

### DIFF
--- a/packages/client/src/highlighter/tokenProvider.ts
+++ b/packages/client/src/highlighter/tokenProvider.ts
@@ -286,13 +286,15 @@ const processAnnotationsForNode = (node: Node, textDocument: string[], reference
 
   if (!node.sourceMap) return nullHighlighting
 
-  return node.metadata.reduce((finalResult, annotation) => mergeHighlightingResults(
+  return (node.metadata ?? []).reduce((finalResult, annotation) => mergeHighlightingResults(
     finalResult, processAnnotation(annotation)
   ), nullHighlighting)
 }
 
 const processCode = (node: Node, textDocument: string[]): WollokNodePlotter[] => {
-  return node.reduce((acumResults, node: Node) =>
+  if (!node) return []
+
+  return node?.reduce((acumResults, node: Node) =>
   {
     const nodeResults = mergeHighlightingResults(processNode(node, textDocument, acumResults.references), processAnnotationsForNode(node, textDocument, acumResults.references))
     return mergeHighlightingResults(acumResults, nodeResults)

--- a/packages/server/src/functionalities/autocomplete/node-completion.ts
+++ b/packages/server/src/functionalities/autocomplete/node-completion.ts
@@ -1,5 +1,5 @@
 import { CompletionItem } from 'vscode-languageserver'
-import { Body, Class, Describe, Entity, Environment, Import, Method, Mixin, New, Node, Package, Program, Reference, Singleton, Test, Variable, implicitImport, match, parentImport, when } from 'wollok-ts'
+import { Body, Class, Describe, Entity, Environment, Field, Import, Method, Mixin, New, Node, Package, Program, Reference, Singleton, Test, Variable, implicitImport, match, parentImport, when } from 'wollok-ts'
 import { logger } from '../../utils/logger'
 import { classCompletionItem, entityCompletionItem, fieldCompletionItem, initializerCompletionItem, parameterCompletionItem, singletonCompletionItem, variableCompletionItem, withImport } from './autocomplete'
 import { optionAsserts, optionConstReferences, optionDescribes, optionImports, optionInitialize, optionMethods, optionModules, optionPrograms, optionPropertiesAndReferences, optionReferences, optionTests } from './options-autocomplete'
@@ -18,7 +18,8 @@ export const completionsForNode = (node: Node): CompletionItem[] => {
       when(Method)(completeMethod),
       when(Describe)(completeDescribe),
       when(Reference<Class>)(completeReference),
-      when(New)(completeNew)
+      when(New)(completeNew),
+      when(Field)(field => completionsForNode(field.parent)),
     )
   } catch (error) {
     logger.error(`✘ Completions for node ${node.kind} (${node.sourceMap} - ${node.sourceFileName}) failed: ${error}`, error)


### PR DESCRIPTION
Resuelve #208 

Ver el test `abort format on error`:

- [Antes](https://github.com/uqbar-project/wollok-lsp-ide/actions/runs/13823065588/job/38672633137)
- [Ahora](https://github.com/uqbar-project/wollok-lsp-ide/actions/runs/14220002973/job/39845435774)

El problema se originaba en un test e2e que tenía un import inválido, entonces el Node era undefined.

De paso metí un fix para #215 