### PR TITLE
Fix #222

### DIFF
--- a/packages/server/src/functionalities/autocomplete/autocomplete.ts
+++ b/packages/server/src/functionalities/autocomplete/autocomplete.ts
@@ -33,6 +33,8 @@ export const completions = (environment: Environment) => (
   return result
 }
 
+export const completionResolve = (_: Environment) => (item: CompletionItem): CompletionItem => item
+
 // -----------------
 // -----MAPPERS-----
 // -----------------

--- a/packages/server/src/functionalities/code-actions.ts
+++ b/packages/server/src/functionalities/code-actions.ts
@@ -8,7 +8,7 @@ type CodeActionResponse = Array<Command | CodeAction>
 export const codeActions = (environment: Environment) => (params: CodeActionParams): CodeActionResponse => {
   const problems = validate(packageFromURI(params.textDocument.uri, environment))
   const problemsInRange = problems.filter(problem => rangeIncludes(toVSCRange(problem.sourceMap), params.range))
-  if(problemsInRange.length === 0) return null
+  if (problemsInRange.length === 0) return []
   return problemsInRange.flatMap(problem => {
     const fixer = fixers[problem.code]
     if (!fixer) return []

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -15,7 +15,7 @@ import {
 } from 'vscode-languageserver/node'
 import { Environment } from 'wollok-ts'
 import { LANG_PATH_REQUEST, STRONG_FILES_CHANGED_REQUEST, WORKSPACE_URI_REQUEST } from '../../shared/definitions'
-import { completions } from './functionalities/autocomplete/autocomplete'
+import { completionResolve, completions } from './functionalities/autocomplete/autocomplete'
 import { codeActions } from './functionalities/code-actions'
 import { codeLenses } from './functionalities/code-lens'
 import { definition } from './functionalities/definition'
@@ -207,6 +207,7 @@ const handlers: readonly [
     [connection.onDocumentFormatting, formatDocument],
     [connection.onDocumentRangeFormatting, formatRange],
     [connection.onCompletion, completions],
+    [connection.onCompletionResolve, completionResolve],
     [connection.onPrepareRename, isRenamable],
     [connection.onRenameRequest, rename(documents)],
     [connection.onHover, typeDescriptionOnHover],


### PR DESCRIPTION
Arregla el error crítico del autocompletado porque la versión nueva de VSCode requiere ahora un onCompletionResolve que antes era opcional.

Lo probamos con el Rasta.