### PR TITLE
Fix #226

### DIFF
--- a/packages/client/src/highlighter/tokenProvider.ts
+++ b/packages/client/src/highlighter/tokenProvider.ts
@@ -2,7 +2,6 @@ import { Annotation, Assignment, Class, Describe, excludeNullish, Field, If, Imp
 import { WollokKeywords, WollokTokenKinds, NamedNode, NodeContext, HighlightingResult, LineResult, WollokNodePlotter } from './definitions'
 import { getLineColumn, mergeHighlightingResults, plotRange, plotSingleLine } from './utils'
 
-
 const ENTER = '\n'
 
 const getKindForLiteral = (node: Literal): string | undefined => {
@@ -307,6 +306,7 @@ const processCode = (node: Node, textDocument: string[]): WollokNodePlotter[] =>
 export const processDocument = (filename: string, textDocument: string): WollokNodePlotter[] => {
   const parsedFile = parse.File(filename)
   const parsedPackage = parsedFile.tryParse(textDocument)
-  const splittedLines = textDocument.split('\n')
+  const EOL = textDocument.includes('\r\n') ? '\r\n' : '\n'
+  const splittedLines = textDocument.split(EOL)
   return excludeNullish(processCode(parsedPackage, splittedLines))
 }


### PR DESCRIPTION
Bueno, me hice un tiempito para ver el issue #226 . Al principio pensé que tenía que ver con que se hacía un split de `\n` y el típico problema de Windows de tener `\r\n` pero aparentemente el problema está en el `tryParse` de Parsimmon de acuerdo a nuestras definiciones (hay que ver el issue que está detallado). Por ahora igual preferí meter un workaround para salir del paso y abrí [este issue en Wollok TS](https://github.com/uqbar-project/wollok-ts/issues/361) para corregir verdaderamente el parser.

En Windows si vos hacés

```wollok
object pepe {
}
object pepita {
}
```

el tryParse de Parsimmon en Linux / Mac te devuelve

```
+ Package
   + Package
     + Singleton
     + Singleton 
```

mientras que en Windows tenés

```
+ Package
   + Singleton
   + Singleton
```

con lo que al procesar solo members[0] solo highlightea el object pepe:

```ts
export const processDocument = (filename: string, textDocument: string): WollokNodePlotter[] => {
  const parsedFile = parse.File(filename)
  const textFile = textDocument
  const parsedPackage = parsedFile.tryParse(textFile)
  const packageNode = parsedPackage.members[0]    // Acá está el tema en Windows

  const splittedLines = textFile.split('\n')
  return excludeNullish(processCode(packageNode, splittedLines))
}
```