### PR TITLE
Fix #228

### DIFF
--- a/packages/server/src/functionalities/code-actions.ts
+++ b/packages/server/src/functionalities/code-actions.ts
@@ -6,8 +6,12 @@ import { packageFromURI, rangeIncludes, toVSCRange, uriFromRelativeFilePath } fr
 type CodeActionResponse = Array<Command | CodeAction>
 
 export const codeActions = (environment: Environment) => (params: CodeActionParams): CodeActionResponse => {
-  const problems = validate(packageFromURI(params.textDocument.uri, environment))
-  const problemsInRange = problems.filter(problem => rangeIncludes(toVSCRange(problem.sourceMap), params.range))
+  const uri = params.textDocument.uri
+  if (!uri) return []
+  const packageUri = packageFromURI(uri, environment)
+  if (!packageUri) return []
+  const problems = validate(packageUri)
+  const problemsInRange = problems.filter(problem => problem.sourceMap && rangeIncludes(toVSCRange(problem.sourceMap), params.range))
   if (problemsInRange.length === 0) return []
   return problemsInRange.flatMap(problem => {
     const fixer = fixers[problem.code]

--- a/packages/server/src/linter.ts
+++ b/packages/server/src/linter.ts
@@ -64,7 +64,7 @@ export const validateTextDocument =
         try {
           const problems = validate(environment)
           sendDiagnostics(connection, problems, allDocuments)
-        } catch (error) {
+        } catch (error: unknown) {
           logger.error(`✘ Validate text document error: ${error}`, error)
           generateErrorForFile(connection, textDocument)
         } finally {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -254,6 +254,8 @@ function syncHandler<Params, Return, PR>(requestHandler: ServerRequestHandler<Pa
     requestProgressReporter.begin()
     try {
       return requestHandler(params, cancel, workDoneProgress, resultProgress)
+    } catch (error) {
+      handleError('Error on handler', error)
     } finally {
       requestProgressReporter.end()
     }

--- a/packages/server/src/utils/vm/environment.ts
+++ b/packages/server/src/utils/vm/environment.ts
@@ -36,7 +36,7 @@ export class EnvironmentProvider {
         timeMeasurer.addTime('Inferring types')
       }
       return environment
-    } catch (error) {
+    } catch (error: unknown) {
       documents.forEach(document => {
         generateErrorForFile(this.connection, document)
       })


### PR DESCRIPTION
Resuelve los popus molestos de #228 

## Ahora

<img width="1453" height="1019" alt="Screenshot 2025-10-28 at 6 22 52 PM" src="https://github.com/user-attachments/assets/4cb92cf3-5f9f-4124-96db-bc758c59fc0c" />

## Con el cambio

Simplemente no aparece el popup de abajo a la derecha. Sí se loguea el error, por el momento seguimos diciendo "File could not be validated" cuando el parser falla.

<img width="2898" height="778" alt="image" src="https://github.com/user-attachments/assets/f659fc08-15ce-44ac-a0eb-1f1f504345a4" />
