### PR TITLE
Setting up wollok-lsp-ide as the default formatter for wollok files and formatOnSave

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -3,7 +3,7 @@ var { defineConfig } = require('@vscode/test-cli')
 module.exports = defineConfig({
   tests: [
     {
-      files: 'out/client/src/test/*.test.js',
+      files: 'out/client/src/test/**/*.test.js',
       version: 'stable',
       extensionDevelopmentPath: __dirname,
       workspaceFolder: `${__dirname}/packages/client/testFixture`,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,10 @@
       "request": "launch",
       "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "${workspaceFolder}/packages/client/testFixture"
+      ],
       "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "autoAttachChildProcesses": true,
       "preLaunchTask": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,9 @@
     "**/.pnp.*": true
   },
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[wollok]": {
+    "editor.defaultFormatter": "uqbar.wollok-lsp-ide",
+    "editor.formatOnSave": true
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,20 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "type": "npm",
+      "script": "compile",
+      "group": "build",
+      "label": "npm: compile",
+      "detail": "Compile the extension"
+    },
+    {
+      "type": "npm",
+      "script": "compile-tests",
+      "group": "build",
+      "label": "npm: compile-tests",
+      "detail": "Compile the extension tests"
+    },
+    {
       "label": "watch",
       "dependsOn": ["npm: watch:tsc", "npm: watch:esbuild"],
       "presentation": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
   "main": "./out/client/src/extension",
   "configurationDefaults": {
     "[wollok]": {
-      "editor.semanticHighlighting.enabled": true
+      "editor.semanticHighlighting.enabled": true,
+      "editor.defaultFormatter": "uqbar.wollok-lsp-ide",
+      "editor.formatOnSave": true
     }
   },
   "contributes": {

--- a/packages/client/testFixture/.vscode/settings.json
+++ b/packages/client/testFixture/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "wollokLSP.typeSystem.enabled": false
+  "wollokLSP.typeSystem.enabled": false,
+  "editor.formatOnSave": true,
+  "[wollok]": {
+    "editor.defaultFormatter": "uqbar.wollok-lsp-ide",
+    "editor.formatOnSave": true
+  },
+  "prettier.enable": false,
+  "prettier.disableLanguages": ["wollok"]
 }


### PR DESCRIPTION
Probably some files are just to setup the instance we launch for testing/debugging and package.json is the actual particular change required.
Now when you launch it it will open the test-fixtures folder (maybe we don't want that ?)

![wollok-autoformat](https://github.com/user-attachments/assets/1ddafbf4-d231-4b8a-878b-ccd6594386a0)
